### PR TITLE
ci: dedupe k8s version matrix in ci-tetragon-create-bob.yaml

### DIFF
--- a/.github/workflows/ci-tetragon-create-bob.yaml
+++ b/.github/workflows/ci-tetragon-create-bob.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04 ,ubuntu-24.04]
         k8s-distribution: [k3s, kind, minikube] #fix k0s => it is simply not reporting any anomalies IG is never loaded
-        kubernetes-version: [ v1.33.2, v1.30.0, v1.31.0, v1.32.0, v1.33.0, v1.33.2] 
+        kubernetes-version: [v1.30.0, v1.31.0, v1.32.0, v1.33.0, v1.33.2] 
     runs-on: ${{ matrix.os }}
 
 


### PR DESCRIPTION
Closes #47

Problem
- The workflow matrix in `.github/workflows/ci-tetragon-create-bob.yaml` listed `v1.33.2` twice
- Duplicate matrix entries spawned duplicate jobs and produced artifact upload name collisions

Changes
- Remove the duplicate `v1.33.2` from `kubernetes-version`
- Did not change/add `max-parallel` here; concurrency was not the cause