### PR TITLE
Seccomp profile writer and parser

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -398,11 +398,3 @@ func writeAppArmorProfile(filename string, config *TemplateConfig, profile *Appl
 	return fmt.Errorf("AppArmor output not implemented")
 }
 
-func parseSeccompProfile(filename string) (*ApplicationProfile, error) {
-	// TODO: Implement Seccomp parsing and mapping to ApplicationProfile
-	return nil, fmt.Errorf("Seccomp parsing not implemented")
-}
-func writeSeccompProfile(filename string, config *TemplateConfig, profile *ApplicationProfile) error {
-	// TODO: Implement serialization to Seccomp format
-	return fmt.Errorf("Seccomp output not implemented")
-}

--- a/src/seccomp.go
+++ b/src/seccomp.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type SeccompProfile struct {
+	DefaultAction string        `json:"defaultAction"`
+	Architectures []string      `json:"architectures,omitempty"`
+	Syscalls      []SeccompRule `json:"syscalls,omitempty"`
+}
+
+type SeccompRule struct {
+	Names  []string `json:"names"`
+	Action string   `json:"action"`
+}
+
+var archToSeccomp = map[string]string{
+	"amd64":   "SCMP_ARCH_X86_64",
+	"arm64":   "SCMP_ARCH_AARCH64",
+	"arm":     "SCMP_ARCH_ARM",
+	"x86":     "SCMP_ARCH_X86",
+	"i386":    "SCMP_ARCH_X86",
+	"ppc64le": "SCMP_ARCH_PPC64LE",
+	"s390x":   "SCMP_ARCH_S390X",
+	"riscv64": "SCMP_ARCH_RISCV64",
+}
+
+var seccompToArch map[string]string
+
+func init() {
+	seccompToArch = make(map[string]string, len(archToSeccomp))
+	for k, v := range archToSeccomp {
+		// For duplicates (x86/i386), first write wins — prefer the canonical name
+		if _, exists := seccompToArch[v]; !exists {
+			seccompToArch[v] = k
+		}
+	}
+}
+
+func writeSeccompProfile(filename string, config *TemplateConfig, profile *ApplicationProfile) error {
+	containers := append(profile.Spec.Containers, profile.Spec.InitContainers...)
+	if len(containers) == 0 {
+		return fmt.Errorf("profile has no containers")
+	}
+
+	multiContainer := len(containers) > 1
+
+	for _, container := range containers {
+		sp := SeccompProfile{
+			DefaultAction: "SCMP_ACT_ERRNO",
+		}
+
+		for _, arch := range profile.Spec.Architectures {
+			if scmpArch, ok := archToSeccomp[arch]; ok {
+				sp.Architectures = append(sp.Architectures, scmpArch)
+			} else {
+				log.Printf("Warning: Unknown architecture %q, skipping", arch)
+			}
+		}
+
+		var syscalls []string
+		for _, sCall := range container.Syscalls {
+			if sCall == "unknown" {
+				log.Printf("Info: Filtering out \"unknown\" syscall (Kubescape sentinel value)")
+				continue
+			}
+			syscalls = append(syscalls, sCall)
+		}
+		sort.Strings(syscalls)
+		syscalls = unique(syscalls)
+
+		if len(syscalls) > 0 {
+			sp.Syscalls = []SeccompRule{
+				{
+					Names:  syscalls,
+					Action: "SCMP_ACT_ALLOW",
+				},
+			}
+		}
+
+		if len(container.Capabilities) > 0 {
+			log.Printf("Info: Dropping %d capabilities — seccomp profiles don't support capability enforcement", len(container.Capabilities))
+		}
+		if len(container.Endpoints) > 0 {
+			log.Printf("Info: Dropping %d endpoints — seccomp profiles don't support network endpoint definitions", len(container.Endpoints))
+		}
+		if len(container.Execs) > 0 {
+			log.Printf("Info: Dropping %d execs — seccomp profiles don't support exec allowlists", len(container.Execs))
+		}
+		if len(container.Opens) > 0 {
+			log.Printf("Info: Dropping %d opens — seccomp profiles don't support file open allowlists", len(container.Opens))
+		}
+
+		data, err := json.MarshalIndent(sp, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling seccomp profile for container %q: %w", container.Name, err)
+		}
+		data = append(data, '\n')
+
+		outPath := filename
+		if multiContainer {
+			ext := filepath.Ext(filename)
+			stem := strings.TrimSuffix(filename, ext)
+			outPath = fmt.Sprintf("%s-%s%s", stem, container.Name, ext)
+		}
+
+		dir := filepath.Dir(outPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("creating output directory: %w", err)
+		}
+
+		if err := os.WriteFile(outPath, data, 0644); err != nil {
+			return fmt.Errorf("writing seccomp profile to %s: %w", outPath, err)
+		}
+
+		log.Printf("Wrote seccomp profile for container %q to %s", container.Name, outPath)
+	}
+
+	return nil
+}
+
+func parseSeccompProfile(filename string) (*ApplicationProfile, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var sp SeccompProfile
+	if err := json.Unmarshal(data, &sp); err != nil {
+		return nil, fmt.Errorf("parsing seccomp JSON: %w", err)
+	}
+
+	var syscalls []string
+	for _, rule := range sp.Syscalls {
+		if rule.Action == "SCMP_ACT_ALLOW" {
+			syscalls = append(syscalls, rule.Names...)
+		} else {
+			log.Printf("Warning: Skipping seccomp rule with action %q (only SCMP_ACT_ALLOW is mapped)", rule.Action)
+		}
+	}
+	sort.Strings(syscalls)
+	syscalls = unique(syscalls)
+
+	var archs []string
+	for _, scmpArch := range sp.Architectures {
+		if arch, ok := seccompToArch[scmpArch]; ok {
+			archs = append(archs, arch)
+		} else {
+			log.Printf("Warning: Unknown seccomp architecture %q, skipping", scmpArch)
+		}
+	}
+
+	// Derive container name from filename
+	base := filepath.Base(filename)
+	containerName := strings.TrimSuffix(base, filepath.Ext(base))
+
+	profile := &ApplicationProfile{
+		APIVersion: "spdx.softwarecomposition.kubescape.io/v1beta1",
+		Kind:       "ApplicationProfile",
+		Metadata: Metadata{
+			Name: containerName,
+		},
+		Spec: ApplicationProfileSpec{
+			Architectures: archs,
+			Containers: []ContainerProfile{
+				{
+					Name:     containerName,
+					Syscalls: syscalls,
+				},
+			},
+		},
+	}
+
+	return profile, nil
+}

--- a/src/seccomp.go
+++ b/src/seccomp.go
@@ -32,16 +32,14 @@ var archToSeccomp = map[string]string{
 	"riscv64": "SCMP_ARCH_RISCV64",
 }
 
-var seccompToArch map[string]string
-
-func init() {
-	seccompToArch = make(map[string]string, len(archToSeccomp))
-	for k, v := range archToSeccomp {
-		// For duplicates (x86/i386), first write wins — prefer the canonical name
-		if _, exists := seccompToArch[v]; !exists {
-			seccompToArch[v] = k
-		}
-	}
+var seccompToArch = map[string]string{
+	"SCMP_ARCH_X86_64":  "amd64",
+	"SCMP_ARCH_AARCH64": "arm64",
+	"SCMP_ARCH_ARM":     "arm",
+	"SCMP_ARCH_X86":     "x86",
+	"SCMP_ARCH_PPC64LE": "ppc64le",
+	"SCMP_ARCH_S390X":   "s390x",
+	"SCMP_ARCH_RISCV64": "riscv64",
 }
 
 func writeSeccompProfile(filename string, config *TemplateConfig, profile *ApplicationProfile) error {

--- a/src/seccomp_test.go
+++ b/src/seccomp_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestArchMapping(t *testing.T) {
+	tests := []struct {
+		goArch      string
+		scmpArch    string
+		shouldExist bool
+	}{
+		{"amd64", "SCMP_ARCH_X86_64", true},
+		{"arm64", "SCMP_ARCH_AARCH64", true},
+		{"arm", "SCMP_ARCH_ARM", true},
+		{"x86", "SCMP_ARCH_X86", true},
+		{"i386", "SCMP_ARCH_X86", true},
+		{"ppc64le", "SCMP_ARCH_PPC64LE", true},
+		{"s390x", "SCMP_ARCH_S390X", true},
+		{"riscv64", "SCMP_ARCH_RISCV64", true},
+		{"mips", "", false},
+	}
+
+	for _, tt := range tests {
+		got, ok := archToSeccomp[tt.goArch]
+		if ok != tt.shouldExist {
+			t.Errorf("archToSeccomp[%q]: exists=%v, want %v", tt.goArch, ok, tt.shouldExist)
+		}
+		if ok && got != tt.scmpArch {
+			t.Errorf("archToSeccomp[%q] = %q, want %q", tt.goArch, got, tt.scmpArch)
+		}
+	}
+
+	for _, tt := range tests {
+		if !tt.shouldExist {
+			continue
+		}
+		rev, ok := seccompToArch[tt.scmpArch]
+		if !ok {
+			t.Errorf("seccompToArch[%q] not found", tt.scmpArch)
+		}
+		if _, ok := archToSeccomp[rev]; !ok {
+			t.Errorf("seccompToArch[%q] = %q, which is not in archToSeccomp", tt.scmpArch, rev)
+		}
+	}
+}
+
+func TestWriteSeccompProfile(t *testing.T) {
+	profile := &ApplicationProfile{
+		Spec: ApplicationProfileSpec{
+			Architectures: []string{"amd64"},
+			Containers: []ContainerProfile{
+				{
+					Name:         "test-container",
+					Syscalls:     []string{"write", "read", "unknown", "accept4", "read"},
+					Capabilities: []string{"NET_ADMIN"},
+					Execs:        []Exec{{Path: "/bin/sh"}},
+					Opens:        []Open{{Path: "/etc/hosts", Flags: []string{"O_RDONLY"}}},
+					Endpoints:    []Endpoint{{Direction: "inbound", Endpoint: "10.0.0.1:80"}},
+				},
+			},
+		},
+	}
+
+	outFile := filepath.Join(t.TempDir(), "test-seccomp.json")
+	err := writeSeccompProfile(outFile, nil, profile)
+	if err != nil {
+		t.Fatalf("writeSeccompProfile failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	var sp SeccompProfile
+	if err := json.Unmarshal(data, &sp); err != nil {
+		t.Fatalf("parsing output JSON: %v", err)
+	}
+
+	if sp.DefaultAction != "SCMP_ACT_ERRNO" {
+		t.Errorf("defaultAction = %q, want SCMP_ACT_ERRNO", sp.DefaultAction)
+	}
+
+	if len(sp.Architectures) != 1 || sp.Architectures[0] != "SCMP_ARCH_X86_64" {
+		t.Errorf("architectures = %v, want [SCMP_ARCH_X86_64]", sp.Architectures)
+	}
+
+	if len(sp.Syscalls) != 1 {
+		t.Fatalf("expected 1 syscall rule, got %d", len(sp.Syscalls))
+	}
+
+	rule := sp.Syscalls[0]
+	if rule.Action != "SCMP_ACT_ALLOW" {
+		t.Errorf("rule action = %q, want SCMP_ACT_ALLOW", rule.Action)
+	}
+
+	expected := []string{"accept4", "read", "write"}
+	if !reflect.DeepEqual(rule.Names, expected) {
+		t.Errorf("syscall names = %v, want %v", rule.Names, expected)
+	}
+}
+
+func TestWriteSeccompMultiContainer(t *testing.T) {
+	profile := &ApplicationProfile{
+		Spec: ApplicationProfileSpec{
+			Containers: []ContainerProfile{
+				{Name: "web", Syscalls: []string{"read", "write"}},
+				{Name: "sidecar", Syscalls: []string{"read", "epoll_wait"}},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "profile.json")
+	err := writeSeccompProfile(outFile, nil, profile)
+	if err != nil {
+		t.Fatalf("writeSeccompProfile failed: %v", err)
+	}
+
+	for _, name := range []string{"profile-web.json", "profile-sidecar.json"} {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", path)
+		}
+	}
+
+	if _, err := os.Stat(outFile); !os.IsNotExist(err) {
+		t.Errorf("expected %s to NOT exist in multi-container mode", outFile)
+	}
+}
+
+func TestParseSeccompProfile(t *testing.T) {
+	sp := SeccompProfile{
+		DefaultAction: "SCMP_ACT_ERRNO",
+		Architectures: []string{"SCMP_ARCH_X86_64", "SCMP_ARCH_AARCH64"},
+		Syscalls: []SeccompRule{
+			{Names: []string{"read", "write", "close"}, Action: "SCMP_ACT_ALLOW"},
+			{Names: []string{"mount"}, Action: "SCMP_ACT_LOG"},
+		},
+	}
+
+	dir := t.TempDir()
+	inFile := filepath.Join(dir, "test-input.json")
+	data, _ := json.Marshal(sp)
+	os.WriteFile(inFile, data, 0644)
+
+	profile, err := parseSeccompProfile(inFile)
+	if err != nil {
+		t.Fatalf("parseSeccompProfile failed: %v", err)
+	}
+
+	if profile.APIVersion != "spdx.softwarecomposition.kubescape.io/v1beta1" {
+		t.Errorf("apiVersion = %q, want kubescape CRD version", profile.APIVersion)
+	}
+	if profile.Kind != "ApplicationProfile" {
+		t.Errorf("kind = %q, want ApplicationProfile", profile.Kind)
+	}
+
+	if len(profile.Spec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(profile.Spec.Containers))
+	}
+
+	container := profile.Spec.Containers[0]
+	expectedSyscalls := []string{"close", "read", "write"}
+	if !reflect.DeepEqual(container.Syscalls, expectedSyscalls) {
+		t.Errorf("syscalls = %v, want %v", container.Syscalls, expectedSyscalls)
+	}
+
+	for _, sc := range container.Syscalls {
+		if sc == "mount" {
+			t.Error("mount should not be included (non-ALLOW action)")
+		}
+	}
+
+	expectedArchs := []string{"amd64", "arm64"}
+	sort.Strings(profile.Spec.Architectures)
+	if !reflect.DeepEqual(profile.Spec.Architectures, expectedArchs) {
+		t.Errorf("architectures = %v, want %v", profile.Spec.Architectures, expectedArchs)
+	}
+
+	if container.Name != "test-input" {
+		t.Errorf("container name = %q, want %q", container.Name, "test-input")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	profile, err := parseKubescapeProfile("../example/redis-profile.yaml")
+	if err != nil {
+		t.Fatalf("parsing redis profile: %v", err)
+	}
+
+	dir := t.TempDir()
+	seccompFile := filepath.Join(dir, "redis-seccomp.json")
+
+	err = writeSeccompProfile(seccompFile, nil, profile)
+	if err != nil {
+		t.Fatalf("writing seccomp: %v", err)
+	}
+
+	roundTripped, err := parseSeccompProfile(seccompFile)
+	if err != nil {
+		t.Fatalf("parsing seccomp: %v", err)
+	}
+
+	var originalSyscalls []string
+	for _, sc := range profile.Spec.Containers[0].Syscalls {
+		if sc != "unknown" {
+			originalSyscalls = append(originalSyscalls, sc)
+		}
+	}
+	sort.Strings(originalSyscalls)
+	originalSyscalls = unique(originalSyscalls)
+
+	rtSyscalls := roundTripped.Spec.Containers[0].Syscalls
+	sort.Strings(rtSyscalls)
+
+	if !reflect.DeepEqual(rtSyscalls, originalSyscalls) {
+		t.Errorf("round-trip syscalls don't match.\ngot:  %v\nwant: %v", rtSyscalls, originalSyscalls)
+	}
+}

--- a/src/seccomp_test.go
+++ b/src/seccomp_test.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -222,5 +226,77 @@ func TestRoundTrip(t *testing.T) {
 
 	if !reflect.DeepEqual(rtSyscalls, originalSyscalls) {
 		t.Errorf("round-trip syscalls don't match.\ngot:  %v\nwant: %v", rtSyscalls, originalSyscalls)
+	}
+}
+
+// Perform Roundtrip test on entire testdata folder.
+func TestRoundTripTestdata(t *testing.T) {
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	files, err := filepath.Glob("../testdata/parameterstudy/**/*.yaml")
+	if err != nil {
+		t.Skipf("globbing testdata: %v", err)
+	}
+
+	if len(files) == 0 {
+		t.Skipf("no testdata profiles found")
+	}
+
+	for _, file := range files {
+		name := filepath.Base(file)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			profile, err := parseKubescapeProfile(file)
+			if err != nil {
+				t.Skipf("not a valid kubescape profile: %v", err)
+			}
+
+			if len(profile.Spec.Containers) == 0 && len(profile.Spec.InitContainers) == 0 {
+				t.Skip("profile has no containers")
+			}
+
+			dir := t.TempDir()
+			seccompFile := filepath.Join(dir, "seccomp.json")
+
+			if err := writeSeccompProfile(seccompFile, nil, profile); err != nil {
+				t.Fatalf("writing seccomp: %v", err)
+			}
+
+			allContainers := append(profile.Spec.Containers, profile.Spec.InitContainers...)
+			multiContainer := len(allContainers) > 1
+
+			for _, container := range allContainers {
+				outPath := seccompFile
+				if multiContainer {
+					ext := filepath.Ext(seccompFile)
+					stem := strings.TrimSuffix(seccompFile, ext)
+					outPath = fmt.Sprintf("%s-%s%s", stem, container.Name, ext)
+				}
+
+				roundTripped, err := parseSeccompProfile(outPath)
+				if err != nil {
+					t.Fatalf("parsing seccomp for container %q: %v", container.Name, err)
+				}
+
+				var expectedSyscalls []string
+				for _, sc := range container.Syscalls {
+					if sc != "unknown" {
+						expectedSyscalls = append(expectedSyscalls, sc)
+					}
+				}
+				sort.Strings(expectedSyscalls)
+				expectedSyscalls = unique(expectedSyscalls)
+
+				rtSyscalls := roundTripped.Spec.Containers[0].Syscalls
+				sort.Strings(rtSyscalls)
+
+				if !reflect.DeepEqual(rtSyscalls, expectedSyscalls) {
+					t.Errorf("container %q: round-trip syscalls don't match.\ngot:  %v\nwant: %v",
+						container.Name, rtSyscalls, expectedSyscalls)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
I was unsure how to approach the open issues so i took a swing at a TODO from the code base instead.
The seccomp tests use the existing parseKubescapeProfile implementation which i suppose is not ideal but I figured it provided a good base to ensure the seccomp parsing had plenty of test profiles to verify against.