### PR TITLE
ci(autotune): enforce score gate for all 4 matrix apps (parity)

### DIFF
--- a/.github/workflows/ci-bobctl-autotune.yaml
+++ b/.github/workflows/ci-bobctl-autotune.yaml
@@ -78,30 +78,45 @@ jobs:
           - misp
           - elk
         include:
-          # Each app needs: functional_tests, attack_suite, app_namespace, protocol.
-          # Optional: profile_match (for apps where profile name != app name).
-          # Deploy logic lives in the Makefile: `make deploy-<app>`
+          # Each app needs: functional_tests, attack_suite, app_namespace,
+          # protocol, score_threshold. Optional: profile_match (for apps
+          # where profile name != app name). Deploy logic lives in the
+          # Makefile: `make deploy-<app>`.
+          #
+          # score_threshold is the max acceptable tuner score (missed+FP).
+          # Parity contract: every app has a gate. Start at 0 for apps that
+          # already converge; widen only with a comment explaining why.
           - app: webapp
             functional_tests: example/webapp-functional-tests.yaml
             attack_suite: example/webapp-attacks.yaml
             app_namespace: webapp
             protocol: http
+            score_threshold: 0
           - app: redis
             functional_tests: example/redis-functional-tests.yaml
             attack_suite: example/redis-attacks.yaml
             app_namespace: redis
             protocol: redis
+            score_threshold: 0
           - app: misp
             functional_tests: example/misp-functional-tests.yaml
             attack_suite: example/misp-attacks.yaml
             app_namespace: misp
             protocol: https
+            # Without this match, "misp" also grep-matches the Helm
+            # sub-chart profiles statefulset-misp-valkey-master and
+            # statefulset-misp-mariadb — the tuner then builds a profile
+            # for valkey while attacks hit the MISP container, and all
+            # profile-dependent detections miss (score 6).
+            profile_match: replicaset-misp
+            score_threshold: 0
           - app: elk
             functional_tests: example/elk-functional-tests.yaml
             attack_suite: example/elk-attacks.yaml
             app_namespace: elk
             protocol: http
             profile_match: el-es
+            score_threshold: 0
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -660,20 +675,26 @@ jobs:
           cp /tmp/tune-output.txt results/ 2>/dev/null || true
 
       - name: Score gate
-        if: always() && matrix.app == 'webapp'
+        if: always()
         run: |
+          APP="${{ matrix.app }}"
+          THRESHOLD="${{ matrix.score_threshold }}"
           if [ ! -f results/metrics.json ]; then
-            echo "FAIL: No metrics.json — tune did not produce output"
+            echo "FAIL ($APP): No metrics.json — tune did not produce output"
             exit 1
           fi
-          BEST_SCORE=$(jq '[to_entries[] | select(.value.phase != "raw-baseline")] | min_by(.value.score) | .value.score' results/metrics.json)
-          echo "Best score: $BEST_SCORE"
-          if [ "$BEST_SCORE" != "0" ]; then
-            echo "FAIL: webapp tune did not achieve perfect score (score=$BEST_SCORE)"
+          BEST_SCORE=$(jq '[to_entries[] | select(.value.phase != "raw-baseline")] | min_by(.value.score) | .value.score // "null"' results/metrics.json)
+          if [ "$BEST_SCORE" = "null" ]; then
+            echo "FAIL ($APP): no scored tune iterations in metrics.json"
+            exit 1
+          fi
+          echo "$APP best score: $BEST_SCORE (threshold: $THRESHOLD)"
+          if [ "$BEST_SCORE" -gt "$THRESHOLD" ]; then
+            echo "FAIL ($APP): tune score $BEST_SCORE exceeds threshold $THRESHOLD"
             jq '[to_entries[] | select(.value.phase != "raw-baseline")] | min_by(.value.score) | .value | {score, missed_detections, false_positives, phase, iteration}' results/metrics.json
             exit 1
           fi
-          echo "PASS: webapp achieved perfect score"
+          echo "PASS ($APP): score $BEST_SCORE within threshold $THRESHOLD"
 
       - name: Validate artifact isolation
         if: always()

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -43,6 +43,7 @@ case "$APP" in
     APP_ATTACKS=example/webapp-attacks.yaml
     APP_SERVICE=webapp-mywebapp
     APP_PORT=8080
+    APP_SCORE_THRESHOLD=0
     ;;
   redis)
     APP_NS=redis
@@ -50,6 +51,7 @@ case "$APP" in
     APP_ATTACKS=example/redis-attacks.yaml
     APP_SERVICE=redis
     APP_PORT=6379
+    APP_SCORE_THRESHOLD=0
     ;;
   misp)
     APP_NS=misp
@@ -58,6 +60,9 @@ case "$APP" in
     APP_SERVICE=misp
     APP_PORT=443
     APP_SCHEME=https
+    # Exclude sub-chart StatefulSets (valkey, mariadb) from profile discovery.
+    APP_PROFILE_MATCH="replicaset-misp"
+    APP_SCORE_THRESHOLD=0
     ;;
   elk)
     APP_NS=elk
@@ -66,6 +71,7 @@ case "$APP" in
     APP_SERVICE=el-es-http
     APP_PORT=9200
     APP_PROFILE_MATCH="el-es"
+    APP_SCORE_THRESHOLD=0
     ;;
   postgres)
     APP_NS=postgres
@@ -74,11 +80,16 @@ case "$APP" in
     APP_SERVICE=pg-rw
     APP_PORT=5432
     APP_PROFILE_MATCH="pg-"
+    APP_SCORE_THRESHOLD=0
     ;;
   *)
     die "Unknown app: $APP (use webapp, redis, misp, elk, or postgres)"
     ;;
 esac
+
+# Allow override for arm64-only drift or exploratory runs without burying the
+# real threshold: SCORE_THRESHOLD=99 ./scripts/local-ci.sh --app redis
+APP_SCORE_THRESHOLD="${SCORE_THRESHOLD:-$APP_SCORE_THRESHOLD}"
 
 APP_SCHEME="${APP_SCHEME:-http}"
 
@@ -362,6 +373,25 @@ bin/bobctl attack \
   --format markdown 2>&1 | tee results/attack-results.md
 set -e
 
+# ── guard against false-green (HTTP/HTTPS service unreachable) ──────────────
+# Mirrors the same-named CI step: fails early if every attack returned code 0
+# (network error / no endpoints), which otherwise lets a broken target pass
+# both the attack step and the downstream score gate.
+if [[ "$APP_SCHEME" == "http" || "$APP_SCHEME" == "https" ]]; then
+  if [[ ! -f results/attack-results.md ]]; then
+    log "FAIL: attack-results.md missing — bobctl attack did not run"
+    exit 1
+  fi
+  NONZERO=$(awk -F'|' '/^\| *[a-z]/ && !/---/ && !/^\| Type \|/ {gsub(/ /,"",$4); if ($4 != "0" && $4 != "") n++} END {print n+0}' results/attack-results.md)
+  TOTAL=$(awk -F'|' '/^\| *[a-z]/ && !/---/ && !/^\| Type \|/ {n++} END {print n+0}' results/attack-results.md)
+  log "Attacks: $NONZERO of $TOTAL returned a non-zero HTTP code"
+  if [[ "$NONZERO" == "0" && "$TOTAL" -gt 0 ]]; then
+    log "FAIL: every attack returned code 0 — target service was unreachable (false-green)"
+    cat results/attack-results.md
+    exit 1
+  fi
+fi
+
 # ── detection report ─────────────────────────────────────────────────────────
 log "=== Detection report ==="
 set +e
@@ -414,6 +444,8 @@ log "=== Results ==="
 ls -la results/ 2>/dev/null || true
 
 # ── score gate ────────────────────────────────────────────────────────────────
+# Parity contract: every app has a threshold and local enforces the same gate
+# CI does. Exit non-zero if exceeded so CI regressions are catchable locally.
 echo
 if [[ -f results/metrics.json ]]; then
   BEST_SCORE=$(python3 -c "
@@ -426,12 +458,19 @@ if tested:
 else:
     print('N/A')
 " 2>/dev/null || echo "N/A")
-  log "Best score: $BEST_SCORE"
-  if [[ "$BEST_SCORE" == "0" ]]; then
+  log "$APP best score: $BEST_SCORE (threshold: $APP_SCORE_THRESHOLD)"
+  if [[ "$BEST_SCORE" == "N/A" ]]; then
+    log "RESULT: No scored tune iterations — treating as failure"
+    exit 1
+  elif (( BEST_SCORE > APP_SCORE_THRESHOLD )); then
+    log "RESULT: FAIL — $APP score $BEST_SCORE exceeds threshold $APP_SCORE_THRESHOLD"
+    exit 1
+  elif (( BEST_SCORE == 0 )); then
     log "RESULT: PERFECT — all attacks detected, zero false positives"
   else
-    log "RESULT: IMPERFECT (best score=$BEST_SCORE) — review results/ for details"
+    log "RESULT: PASS — $APP score $BEST_SCORE within threshold $APP_SCORE_THRESHOLD"
   fi
 else
   log "RESULT: No metrics.json produced — tune may have failed"
+  exit 1
 fi


### PR DESCRIPTION
## Summary

- Per-app `score_threshold` (default 0) in the CI matrix. The `Score gate` step now fires for every app, not only webapp.
- `scripts/local-ci.sh` mirrors the same contract with a `SCORE_THRESHOLD` env-var override for legitimate platform drift (arm64 kernel/syscall differences).
- Adds a false-green HTTP guard to `local-ci.sh` (same behaviour as the CI step of the same name).
- Pins `profile_match: replicaset-misp` so the Helm sub-chart StatefulSets (`misp-valkey-master`, `misp-mariadb`) are excluded from profile discovery.
- Bumps the `pkg` submodule pointer.

## Why

Previously only webapp had a hard score gate; `redis`, `misp`, and `elk` were allowed to `continue-on-error` with no threshold enforcement, so any of them could regress silently. This PR makes the gate symmetric — every matrix cell gates on its own score.

## Matrix outcome with the gate enabled

| App    | 22.04 | 24.04 | Threshold |
|--------|-------|-------|-----------|
| webapp | pass  | pass  | 0         |
| redis  | pass  | pass  | 0         |
| elk    | pass  | pass  | 0         |
| misp   | fail (score 6) | fail (score 6) | 0 |

`misp` is intentionally left failing. Its persistent 6 missed detections are a real tuning gap, not a flake, and the parity contract only has teeth if we make that gap visible. A follow-up PR will drive MISP to 0 (likely by splitting MISP's multi-container deployment into per-container attack suites so each container is gated against its own protocol).

## Test plan

- [x] Gate fires for every matrix cell (not just webapp)
- [x] A non-zero score on any cell fails the job — confirmed on MISP ×2
- [x] A zero score passes — confirmed on webapp ×2, redis ×2, elk ×2
- [x] `local-ci.sh` mirrors the same behaviour