### PR TITLE
release: sbob-rc1 — pin storage + NA to sbob-rc1-2026-05-16 + autotune iterate-on-validation fix

### DIFF
--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -1,12 +1,12 @@
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: "sbob-wildcards-2026-05-15"
+    tag: "sbob-rc1-2026-05-16"
 
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: "sbob-wildcards-2026-05-15"
+    tag: "sbob-rc1-2026-05-16"
   config:
     maxLearningPeriod: 2m
     learningPeriod: 2m 


### PR DESCRIPTION
## Summary

Promotes the rc1 image set + the bobctl autotune fix needed to validate it end-to-end.

- **Image pins:** storage + node-agent updated from `sbob-wildcards-2026-05-15` to `sbob-rc1-2026-05-16` in `kubescape/values.yaml`. These tags carry the convergence of the wildcards + signing surface across both repos.
- **pkg submodule bump:** `f27cdf8 → 8472abb` (entlein/bob#15). Includes the autotune iterate-on-validation fix that's required for the postgres-vuln matrix leg to pass on the new images.

## Validation

Workflow run `25963673310` (`CI - bobctl tune` on `release/sbob-rc1` @ ac6f14a): all 8 app matrix legs green (redis, webapp, mariadb, postgres, postgres-vuln, misp, elk + Build).

Pre-rc1 run on the same branch (`25962429743`) failed at the postgres-vuln score gate — both the image pin and the submodule bump are needed for the green run.

## Companion PR

`entlein/bob#15` — the tuner fix that this PR's submodule bump pulls in. Merging this PR before that one would leave `pkg/main` behind the SHAs the chart references, which is OK for the rc1 branch but undesirable for `main` long-term.

## Test plan

- [x] `kubescape/values.yaml` images pinned to `sbob-rc1-2026-05-16`
- [x] `pkg` submodule pointer matches `entlein/bob#15` HEAD
- [x] Full autotune matrix green on rc1 images (run 25963673310)
- [ ] Reviewer: confirm intended merge ordering (this PR vs the submodule PR)