### PR TITLE
ci(e2e): submodule bump for inner PR #16 + add branch to workflow triggers

### DIFF
--- a/.github/workflows/ci-bobctl-autotune.yaml
+++ b/.github/workflows/ci-bobctl-autotune.yaml
@@ -10,6 +10,7 @@ on:
       - feat/mariadb
       - feat/network-endpoint-tuning
       - feat/postgres-endpoint-attacks
+      - feat/tuning-pipeline-bench-e2e
     paths:
       - 'pkg'
       - 'pkg/**'

--- a/.github/workflows/ci-bobctl-lint.yaml
+++ b/.github/workflows/ci-bobctl-lint.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Clone storage dependency
         run: |
-          git clone --depth 1 --branch merge/upstream-profile-rearch https://github.com/k8sstormcenter/storage.git ../storage
+          git clone --depth 1 --branch main https://github.com/k8sstormcenter/storage.git ../storage
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -65,7 +65,7 @@ jobs:
 
       - name: Clone storage dependency
         run: |
-          git clone --depth 1 --branch merge/upstream-profile-rearch https://github.com/k8sstormcenter/storage.git ../storage
+          git clone --depth 1 --branch main https://github.com/k8sstormcenter/storage.git ../storage
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/ci-bobctl-lint.yaml
+++ b/.github/workflows/ci-bobctl-lint.yaml
@@ -9,6 +9,7 @@ on:
       - feat/mariadb
       - feat/network-endpoint-tuning
       - feat/postgres-endpoint-attacks
+      - feat/tuning-pipeline-bench-e2e
     paths:
       - 'pkg/**'
       - '.github/workflows/ci-bobctl-lint.yaml'


### PR DESCRIPTION
## Purpose

Run the autotune e2e matrix (\`ci-bobctl-autotune.yaml\`: 7 apps on k3s 1.33.3) against the compaction-pipeline refactor + Network Normalizer landing on inner PR #16 (\`entlein/bob#16\`).

This is the **last verification gap** for inner PR #16 — until now it had only unit tests, one integration test, and \`local-ci-unit.sh\` component tests. None of those exercise the new code against a real cluster + live NetworkNeighborhood.

## Changes

- Bump \`pkg/\` submodule pointer: \`a5d11cb → 3c3f51b\` (7 inner commits).
- Add \`feat/tuning-pipeline-bench-e2e\` to BOTH workflow trigger allowlists (\`ci-bobctl-autotune.yaml\` + \`ci-bobctl-lint.yaml\`) so push to this branch fires the full matrix without needing main.

## What's in the inner bump

| Commit | Summary |
|---|---|
| \`dc93047\` | refactor(profile): compaction.Engine + wildcard pkg, align tuner to storage CompareDynamic contract |
| \`47c3cd3\` | fix(compaction): swap WriteString+Sprintf for Fprintf (lint QF1012) |
| \`63124d9\` | fix(compaction): address CodeRabbit PR #16 findings (n=10 bench regen + ⋯→* fixture + nil guard + Fatalf length checks) |
| \`15da7c1\` | docs(measurement): full bobctl callgraph + goroutine inventory |
| \`31d9789\` | feat(network): Normalizer + tuner wiring; delete dead Collapse helpers |
| \`8f6046c\` | merge: origin/main into feat/tuning-pipeline-bench (resolve tuner.go best-nn.yaml overlap) |
| \`3c3f51b\` | test(network): integration test for Normalizer wiring in tuner |

## Network Normalizer (the biggest behavioural change)

Replaces threshold-based collapse with portable-placeholder normalization on the saved \`best-nn.yaml\`:

- **IPs**: RFC 1918 (10/8, 172.16/12, 192.168/16) → network base + REPLACE comment. Loopback / cloud-metadata / RFC 5737 doc / public IPs stay literal.
- **Ports**: ephemeral (32768-60999) or NodePort default (30000-32767) → \`0\` (any-port). Well-known + app-declared kept.
- **DNS**: cluster-internal with autogenerated first label → \`*.<rest>\`. Stable cluster-internal (\`kubernetes.default...\`, \`kube-dns...\`) + external DNS kept.

Wired into \`tuner.go::Run\` at the best-nn.yaml save step; every rewrite is logged via \`t.logf\` so the deployer sees what literal was observed at tune time.

## Test plan

- [ ] \`CI - bobctl lint & test\` green
- [ ] \`CI - bobctl tune\` matrix (7 apps × k3s 1.33.3 × ubuntu-24.04) — observe each app's tune output, in particular \`best-nn.yaml\` should now contain the normalized form
- [ ] Verify \`NN-normalise [...]\` log lines appear in tune output for at least one app whose NN has installation-specific values
- [ ] No regression on apps that have no NN to normalize (empty-NN soft-failure case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)