### PR TITLE
ci: publish log4j-chain images to ghcr (replace ttl.sh)

### DIFF
--- a/.github/workflows/ci-log4j-chain-images.yaml
+++ b/.github/workflows/ci-log4j-chain-images.yaml
@@ -1,0 +1,89 @@
+name: CI - log4j chain images
+
+# Builds and publishes the four log4j-chain demo images
+# (example/log4j-chain/) to GHCR. Mirrors ci-chain-images.yaml's
+# shape; uses immutable GitHub Actions SHAs per the repo's pinning
+# policy.
+#
+# Tags pushed (per component):
+#   - ghcr.io/k8sstormcenter/log4j-chain-<component>:<short-sha>
+#   - ghcr.io/k8sstormcenter/log4j-chain-<component>:<branch>
+#   - ghcr.io/k8sstormcenter/log4j-chain-<component>:latest    (main only)
+#
+# Replaces the ttl.sh 24h-rot path that was breaking fresh-PG
+# provisioning. Consumers are example/log4j-chain/{backend-b,backend-c,
+# log4j-chain,log4j-attacks}.yaml — those already reference
+# ghcr.io/k8sstormcenter/log4j-chain-<component>:latest.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'example/log4j-chain/backend/**'
+      - 'example/log4j-chain/attacker/**'
+      - '.github/workflows/ci-log4j-chain-images.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: ${{ matrix.component }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: log4j-chain-backend-vulnerable
+            context: example/log4j-chain/backend
+            dockerfile: example/log4j-chain/backend/Dockerfile.vulnerable
+          - component: log4j-chain-backend-contained
+            context: example/log4j-chain/backend
+            dockerfile: example/log4j-chain/backend/Dockerfile.contained
+          - component: log4j-chain-backend-patched
+            context: example/log4j-chain/backend
+            dockerfile: example/log4j-chain/backend/Dockerfile.patched
+          - component: log4j-chain-attacker
+            context: example/log4j-chain/attacker
+            dockerfile: example/log4j-chain/attacker/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH_SAFE="${GITHUB_REF_NAME//\//-}"
+          IMG=ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
+          TAGS="${IMG}:${SHORT_SHA},${IMG}:${BRANCH_SAFE}"
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            TAGS="${TAGS},${IMG}:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "primary=${IMG}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          # amd64 only — the demo cluster runs amd64 (oracle-vm runner)
+          # and the maven builds + JDK base images take significantly
+          # longer multi-arch. arm64 can be added if a consumer needs it.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
The four log4j-chain demo images
(backend-{vulnerable,contained,patched} + attacker) currently rot on ttl.sh after 24h. That keeps breaking fresh-PG provisioning when the makefile / cluster-deploy pulls them; the manifests in example/log4j-chain/{backend-b,backend-c,log4j-chain,log4j-attacks}.yaml already reference ghcr.io/k8sstormcenter/log4j-chain-<component>:latest, they just had nothing publishing them there.

This workflow mirrors ci-chain-images.yaml shape: matrix per component, SHA + branch + latest tags, pinned GitHub Actions SHAs per repo policy. Triggers only on changes under example/log4j-chain/backend/ or example/log4j-chain/attacker/ + the workflow file itself.

amd64-only — the demo cluster is amd64 and the maven builds + JDK base images take significantly longer multi-arch. arm64 can be added if a consumer ever needs it.

No smoke-test step: the existing chain workflow's /healthz check doesn't generalise to the attacker (marshalsec LDAP + python HTTP serving Payload.class — no health endpoint). Push success is the green signal; the demo runbooks exercise the images end-to-end.

Flagged by dx-agent in k8sstormcenter/pixie#47 — needed for the #7 pgsql re-test and the M6 combined run.