### PR TITLE
sbobs(log4j): allow resolved psql path in chain-backend AP

### DIFF
--- a/_artifacts/log4j-sbobs/ap-chain-backend.yaml
+++ b/_artifacts/log4j-sbobs/ap-chain-backend.yaml
@@ -50,6 +50,9 @@ spec:
         # on /bin/sh, not on psql.
         - path: /usr/bin/psql
           args: ["/usr/bin/psql"]
+        # resolved real binary behind the /usr/bin/psql wrapper; ⋯⋯ = any args
+        - path: /usr/lib/postgresql/18/bin/psql
+          args: ["/usr/lib/postgresql/18/bin/psql", "⋯⋯"]
       opens:
         # Application jar + JVM startup ladder
         - path: /app/app.jar


### PR DESCRIPTION
The backend SBoB (`_artifacts/log4j-sbobs/ap-chain-backend.yaml`) allow-lists `/usr/bin/psql`, but that's a symlink → `pg_wrapper` → the real binary `/usr/lib/postgresql/18/bin/psql`. node-agent traces the **resolved** path, so a legitimate `psql` call (the payload's DB read) raised a spurious **R0001** under the resolved path.

This adds the resolved binary with an exec-arg wildcard (`⋯⋯`) so `psql` stays allowed while the deviations that matter still fire.

**Verified live** on a k3s rig with `sbob-rc3`: after this change the Log4Shell scenario-A detection is:
- `R0001` → `/bin/sh`, `base32`, `getent`, `tr`, `cut` (the RCE shell + DNS-exfil pipeline)
- `psql` → **no alert** (allowed — the attacker abuses a permitted DB client)
- `R0005` → the `…exfil.attacker.example.com` DNS exfil