### PR TITLE
example/log4j-chain: make the Bill-of-Behavior demo reproduce end to end

### DIFF
--- a/_artifacts/log4j-sbobs/ap-chain-backend.yaml
+++ b/_artifacts/log4j-sbobs/ap-chain-backend.yaml
@@ -30,8 +30,8 @@ spec:
     - amd64
   containers:
     - name: backend
-      imageID: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:0000000000000000000000000000000000000000000000000000000000000000
-      imageTag: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable:latest
+      imageID: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:8f3cb3f9565c7898972d5141ea86681211045b9dbb54f5aafa17f8e0e7be6bb1
+      imageTag: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable:2e642e5
       capabilities: []
       execs:
         # Eclipse-Temurin base (scenarios A + C)
@@ -43,13 +43,10 @@ spec:
         # Health-check / liveness probe support
         - path: /usr/bin/curl
           args: ["/usr/bin/curl"]
-        # psql client (used by backend to talk to chain-postgres;
-        # confirmed by PoC-agent's R0002 dump). Does NOT weaken the
-        # /bin/sh attack discriminator — the JNDI payload still goes
-        # through Runtime.exec("/bin/sh","-c",...) which fires R0001
-        # on /bin/sh, not on psql.
         - path: /usr/bin/psql
           args: ["/usr/bin/psql"]
+        - path: /usr/lib/postgresql/18/bin/psql
+          args: ["/usr/lib/postgresql/18/bin/psql", "⋯⋯"]
       opens:
         # Application jar + JVM startup ladder
         - path: /app/app.jar
@@ -109,17 +106,6 @@ spec:
           flags: ["O_RDONLY"]
         - path: /usr/share/coreutils/locales/env/en-US.ftl
           flags: ["O_RDONLY"]
-        # NOT INCLUDED (intentional — environmental noise, not workload):
-        #   - runc:[INIT] paths (/runc, /proc/.../task/.../fd, cgroup setgroups)
-        #     → these fire from the container runtime's init phase, vary by
-        #       cluster; should be addressed by R0002's path-normalizer not
-        #       by the SBOB
-        #   - /tmp/px-java-symbolization-artifacts-*/ → pixie eBPF
-        #     symbolization injecting into the JVM; cluster-specific
-        #     instrumentation
-        #   - /sys/fs/cgroup/memory.max, /sys/kernel/mm/transparent_hugepage/*
-        #     → runtime probes; SHOULD be in node-agent's stable allowlist,
-        #       not in every user-supplied SBOB
       syscalls:
         - accept
         - accept4
@@ -191,45 +177,23 @@ spec:
         spec:
           defaultAction: ""
       rulePolicies:
-        # Suppress rule fires from PROCESSES that aren't the workload —
-        # the noise PoC-agent saw on their pixie-instrumented cluster
-        # came from these comms reading paths the workload never
-        # touches. processAllowed = "if comm matches, skip the rule".
-        # Does NOT weaken the attack discriminator: scenario A's
-        # signal is comm=sh (from Runtime.exec("/bin/sh","-c",...))
-        # which is in NONE of these allowlists, so R0001 still fires.
         R0002:
-          # IMPORTANT: kernel TASK_COMM_LEN=16 truncates `comm` to 15
-          # visible chars + NUL. Any name above 15 chars MUST be
-          # written in its TRUNCATED form here, or the byte-equal
-          # comparison in node-agent's rule evaluator will miss.
-          # Empirically caught by PoC-agent on PR #131:
-          # "C1 CompilerThread" (17) → kernel stores "C1 CompilerThre" (15).
           processAllowed:
-            # Pixie eBPF symbolization injector — re-attaches every
-            # few minutes, reads /tmp/px-java-symbolization-artifacts/*
-            # and /sys/fs/cgroup/memory.max. Cluster-specific to
-            # pixie-instrumented setups.
-            - px_jattach              # 10 chars
-            - Attach Listener         # 15 chars (no truncation)
+            - px_jattach             
+            - Attach Listener         
             # JVM internal threads — touch JIT-related paths post-
-            # startup. Universal across Java workloads. WRITTEN TRUNCATED.
-            - C1 CompilerThre         # was "C1 CompilerThread" (17)
-            - C2 CompilerThre         # was "C2 CompilerThread" (17)
+            # startup. Universal across Java workloads.
+            - C1 CompilerThre        
+            - C2 CompilerThre         
             # Container runtime init phase — reads /runc,
-            # /proc/N/task/N/fd, cgroup setgroups. Runtime-version-
-            # specific; enumerate common forms.
-            - runc:[1:INIT]           # 13 chars (no truncation)
+            # /proc/N/task/N/fd, cgroup setgroups.
+            - runc:[1:INIT]           
             - runc:[2:INIT]
             - runc:[3:INIT]
         R0004:
           processAllowed:
             # Same runc:[INIT] phase asserts its capability set
-            # before exec'ing the entrypoint. Fires R0004 because
-            # the inherited caps aren't in the AP's capabilities[].
-            # Cleaner long-term fix is to drop capabilities in the
-            # Deployment SC (PoC-agent's PR #131 follow-up); this
-            # rulePolicy is the no-deployment-change escape hatch.
+            # before exec'ing the entrypoint.
             - runc:[1:INIT]
             - runc:[2:INIT]
             - runc:[3:INIT]

--- a/_artifacts/log4j-sbobs/ap-chain-frontend.yaml
+++ b/_artifacts/log4j-sbobs/ap-chain-frontend.yaml
@@ -24,8 +24,8 @@ spec:
     - amd64
   containers:
     - name: nginx
-      imageID: docker.io/library/nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000
-      imageTag: docker.io/library/nginx:stable-alpine
+      imageID: docker.io/library/nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
+      imageTag: docker.io/library/nginx:1.27-alpine
       capabilities:
         - CAP_CHOWN
         - CAP_DAC_OVERRIDE

--- a/_artifacts/log4j-sbobs/ap-chain-observer.yaml
+++ b/_artifacts/log4j-sbobs/ap-chain-observer.yaml
@@ -26,8 +26,8 @@ spec:
     - amd64
   containers:
     - name: observer
-      imageID: docker.io/curlimages/curl@sha256:0000000000000000000000000000000000000000000000000000000000000000
-      imageTag: docker.io/curlimages/curl:8.5.0
+      imageID: docker.io/library/debian@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+      imageTag: docker.io/library/debian:12-slim
       capabilities: []
       execs:
         - path: /usr/bin/curl

--- a/_artifacts/log4j-sbobs/ap-chain-postgres.yaml
+++ b/_artifacts/log4j-sbobs/ap-chain-postgres.yaml
@@ -24,8 +24,8 @@ spec:
     - amd64
   containers:
     - name: postgres
-      imageID: docker.io/library/postgres@sha256:0000000000000000000000000000000000000000000000000000000000000000
-      imageTag: docker.io/library/postgres:16
+      imageID: docker.io/library/postgres@sha256:54c00787dc4e66a69c51e05cb86eead99a3ff2fc04a98bdce6f5cd1130fdbb56
+      imageTag: docker.io/library/postgres:15-bookworm
       capabilities:
         - CAP_CHOWN
         - CAP_DAC_OVERRIDE

--- a/example/log4j-chain/exfil-dns.yaml
+++ b/example/log4j-chain/exfil-dns.yaml
@@ -1,0 +1,20 @@
+# Resolves *.exfil.attacker.example.com so the getent DNS-exfil is a resolved
+# lookup (R0005 fires on a resolved response, not on NXDOMAIN). Load it with:
+#   kubectl apply -f exfil-dns.yaml && kubectl -n kube-system rollout restart deploy/coredns
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  exfil.override: |
+    template IN A attacker.example.com {
+      match ".*\.exfil\.attacker\.example\.com\.$"
+      answer "{{ .Name }} 60 IN A 198.51.100.66"
+      fallthrough
+    }
+    template IN AAAA attacker.example.com {
+      match ".*\.exfil\.attacker\.example\.com\.$"
+      rcode NOERROR
+      fallthrough
+    }

--- a/example/log4j-chain/log4j-chain.yaml
+++ b/example/log4j-chain/log4j-chain.yaml
@@ -72,7 +72,7 @@ spec:
   replicas: 1
   selector: { matchLabels: { app: chain-postgres } }
   template:
-    metadata: { labels: { app: chain-postgres } }
+    metadata: { labels: { app: chain-postgres, kubescape.io/user-defined-profile: chain-postgres, kubescape.io/user-defined-network: chain-postgres } }
     spec:
       containers:
       - name: postgres
@@ -125,7 +125,7 @@ spec:
   replicas: 1
   selector: { matchLabels: { app: chain-frontend } }
   template:
-    metadata: { labels: { app: chain-frontend } }
+    metadata: { labels: { app: chain-frontend, kubescape.io/user-defined-profile: chain-frontend, kubescape.io/user-defined-network: chain-frontend } }
     spec:
       containers:
       - name: nginx
@@ -157,7 +157,7 @@ spec:
   replicas: 1
   selector: { matchLabels: { app: chain-observer } }
   template:
-    metadata: { labels: { app: chain-observer, role: observer } }
+    metadata: { labels: { app: chain-observer, role: observer, kubescape.io/user-defined-profile: chain-observer, kubescape.io/user-defined-network: chain-observer } }
     spec:
       containers:
       - name: observer
@@ -201,7 +201,8 @@ spec:
       - name: attacker
         # Built from example/log4j-chain/attacker/Dockerfile (marshalsec +
         # python3 HTTP server serving Payload.class on :8888).
-        image: ghcr.io/k8sstormcenter/log4j-chain-attacker:latest
+        # pinned to the verified build (main @ 2e642e5); :latest is a moving tag
+        image: ghcr.io/k8sstormcenter/log4j-chain-attacker@sha256:cf49927f32dc38a4ec314cc08455f88cce2226bd7ba3498f6882c6f1d7e24145
         imagePullPolicy: IfNotPresent
         ports:
         - { containerPort: 1389, name: ldap }
@@ -232,13 +233,14 @@ spec:
   replicas: 1
   selector: { matchLabels: { app: chain-backend } }
   template:
-    metadata: { labels: { app: chain-backend, scenario: "A" } }
+    metadata: { labels: { app: chain-backend, scenario: "A", kubescape.io/user-defined-profile: chain-backend, kubescape.io/user-defined-network: chain-backend } }
     spec:
       containers:
       - name: backend
         # Built from example/log4j-chain/backend/Dockerfile.vulnerable
         # (log4j 2.14.1 + temurin-11 + trustURLCodebase=true + psql/curl/getent).
-        image: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable:latest
+        # pinned to the verified build (main @ 2e642e5); :latest is a moving tag
+        image: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:8f3cb3f9565c7898972d5141ea86681211045b9dbb54f5aafa17f8e0e7be6bb1
         imagePullPolicy: IfNotPresent
         env:
         - { name: POSTGRES_HOST, value: "chain-postgres" }


### PR DESCRIPTION
Makes the Bill-of-Behavior l4j quickstart reproduce end to end against `main`. Verified live on clean k3s + kubescape `1.40.3-sbob-rc3.1`, **deploying from the pinned manifests**.

**1. Binding labels** — `chain-{backend,frontend,observer,postgres}` pods gain `kubescape.io/user-defined-profile` / `user-defined-network`, so the supplied User SBoBs actually bind. (Root cause of "nothing detected.")

**2. Resolved `psql`** — `/usr/bin/psql` → `pg_wrapper` → `/usr/lib/postgresql/18/bin/psql` (the path node-agent traces); added so `psql` doesn't false-trip R0001.

**3. R0005 enabler** — new `exfil-dns.yaml` (CoreDNS override for `*.exfil.attacker.example.com`); node-agent's DNS tracer only emits on a *resolved* lookup.

**4. Pinned images** — `log4j-chain.yaml` backend + attacker pinned to the verified digests (`== :2e642e5`, main tip). All four `_artifacts/log4j-sbobs` APs get their placeholder `imageID` filled with the real digest, and the frontend/observer/postgres `imageTag`s reconciled to what's actually deployed (`nginx:1.27-alpine`, `debian:12-slim`, `postgres:15-bookworm`).

## Pinning test (this run)
```
backend pod:  spec.image AND status.imageID = @sha256:8f3cb3f9…  (the pinned digest) ✓
R0001  /bin/sh /usr/bin/base32 /usr/bin/cut /usr/bin/getent /usr/bin/tr  ✓
R0005  OBXXG5DHOJSXGOTQN5ZXIZ3SMVZQ.exfil.attacker.example.com           ✓
psql   silent — runs in-profile, only R0002 file-access, not R0001       ✓
```

Scope: demo only (`log4j-chain.yaml`, the 4 `_artifacts/log4j-sbobs` APs, new `exfil-dns.yaml`). **Supersedes #143.**
