### PR TITLE
example/log4j-chain: valid default name for attack-pod (copy-paste apply)

### DIFF
--- a/example/log4j-chain/attack-pod.yaml
+++ b/example/log4j-chain/attack-pod.yaml
@@ -6,13 +6,13 @@
 # substitute it — none of the Make/bash/ssh shell layers between the host
 # and the attack pod's curl ever sees a $ character to eat.
 #
-# Idempotency: Makefile's IN_CLUSTER_ATTACK deletes any previous attack-<X>
-# pod before applying this. Name suffix is overridden per scenario by sed.
+# Idempotency: delete any previous attack-<X> pod before re-applying. Valid
+# lowercase name so `kubectl apply -f` works as-is (no substitution needed).
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: attack-PLACEHOLDER
+  name: attack-a
   namespace: log4j-poc
 spec:
   restartPolicy: Never


### PR DESCRIPTION
`attack-PLACEHOLDER` is uppercase → an invalid k8s name, so it can't be `kubectl apply`d without a sed substitution. Rename to `attack-a` so the quickstart's `curl … | kubectl -n log4j-poc apply -f -` works copy-paste, no substitution.