### PR TITLE
java-poc golden source: medical-named, digest-pinned test apps + SBoBs

### DIFF
--- a/example/java-poc/00-namespaces.yaml
+++ b/example/java-poc/00-namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: java-poc
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pathogen-ns

--- a/example/java-poc/10-postgres.yaml
+++ b/example/java-poc/10-postgres.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+data:
+  seed.sql: |
+    CREATE TABLE users (
+        id SERIAL PRIMARY KEY,
+        email TEXT,
+        full_name TEXT,
+        created_at TIMESTAMP DEFAULT NOW()
+    );
+    INSERT INTO users (email, full_name) VALUES
+        ('alice@example.com', 'Alice Anderson'),
+        ('bob@example.com',   'Bob Brown'),
+        ('carol@example.com', 'Carol Carter');
+kind: ConfigMap
+metadata:
+  name: pg-seed
+  namespace: java-poc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: java-poc
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: postgres
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: postgres
+        kubescape.io/user-defined-network: postgres
+        kubescape.io/user-defined-profile: postgres
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: trust
+            - name: POSTGRES_DB
+              value: appdb
+          image: postgres:16
+          imagePullPolicy: IfNotPresent
+          name: postgres
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /docker-entrypoint-initdb.d
+              name: seed
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: pg-seed
+          name: seed
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: java-poc
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    app: postgres
+  type: ClusterIP

--- a/example/java-poc/20-frontend.yaml
+++ b/example/java-poc/20-frontend.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        location / {
+            proxy_pass http://backend:8080;
+            proxy_set_header User-Agent $http_user_agent;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+kind: ConfigMap
+metadata:
+  name: frontend-conf
+  namespace: java-poc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: java-poc
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: frontend
+        kubescape.io/user-defined-network: frontend
+        kubescape.io/user-defined-profile: frontend
+    spec:
+      containers:
+        - image: nginx:1.27-alpine
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: conf
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: frontend-conf
+          name: conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: java-poc
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: frontend
+  type: NodePort

--- a/example/java-poc/30-backend.yaml
+++ b/example/java-poc/30-backend.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    scenario: A
+  name: backend
+  namespace: java-poc
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: backend
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: backend
+        kubescape.io/user-defined-network: backend
+        kubescape.io/user-defined-profile: backend
+        scenario: A
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: POSTGRES_DB
+              value: appdb
+            - name: POSTGRES_USER
+              value: postgres
+            - name: JAVA_TOOL_OPTIONS
+              value: -Dnetworkaddress.cache.negative.ttl=0 -Dnetworkaddress.cache.ttl=5
+          image: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:72655e5a5523f578f99544ba7514aeb067f219d09811ea77235dba8bcb6cefb5
+          imagePullPolicy: IfNotPresent
+          name: backend
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: java-poc
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: backend
+  type: ClusterIP

--- a/example/java-poc/40-observer.yaml
+++ b/example/java-poc/40-observer.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    role: observer
+  name: observer
+  namespace: java-poc
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: observer
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: observer
+        kubescape.io/user-defined-network: observer
+        kubescape.io/user-defined-profile: observer
+        role: observer
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                curl -sf http://backend:8080/api/products \
+                  -H 'User-Agent: observer/1.0' \
+                  -o /dev/null || true
+                sleep 30
+              done
+          image: curlimages/curl:8.6.0
+          imagePullPolicy: IfNotPresent
+          name: observer
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: observer
+  namespace: java-poc
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: observer
+  type: ClusterIP

--- a/example/java-poc/50-pathogen.yaml
+++ b/example/java-poc/50-pathogen.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pathogen
+  namespace: pathogen-ns
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: pathogen
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: pathogen
+    spec:
+      containers:
+        - image: ghcr.io/k8sstormcenter/log4j-chain-attacker@sha256:c4dd5f69bce861adfd95792b267cd696b69395d043cb3e5c88776c942270f1ef
+          imagePullPolicy: IfNotPresent
+          name: pathogen
+          ports:
+            - containerPort: 1389
+              name: ldap
+              protocol: TCP
+            - containerPort: 8888
+              name: http
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pathogen
+  namespace: pathogen-ns
+spec:
+  ports:
+    - name: ldap
+      port: 1389
+      protocol: TCP
+      targetPort: 1389
+    - name: http
+      port: 8888
+      protocol: TCP
+      targetPort: 8888
+  selector:
+    app: pathogen
+  type: ClusterIP

--- a/example/java-poc/README.md
+++ b/example/java-poc/README.md
@@ -1,0 +1,62 @@
+# java-poc — golden source for the SOC e2e test apps
+
+This directory is the **single source of truth** for the sample workloads the SOC
+end-to-end / calibration suite drives (pixie fork `src/e2e_test/adaptive_export_loadtest`,
+`TestJavaPocCalibration`). Previously these manifests lived only ephemerally on a
+rig (applied inline, medical-named) while the on-disk copies under
+`../log4j-chain/` used the older `log4j-poc` / `chain-*` / `attacker-ns` naming.
+This dir captures the exact working, medically-named, digest-pinned deployment.
+
+## What it deploys
+
+| Namespace | Workload | Image | Role |
+|---|---|---|---|
+| `java-poc` | `backend` | `log4j-chain-backend-vulnerable@sha256:72655e…` | the vulnerable Java app (scenario A) |
+| `java-poc` | `frontend` | `nginx:1.27-alpine` | edge |
+| `java-poc` | `postgres` | `postgres:16` | app DB (PII the disease hemorrhages) |
+| `java-poc` | `observer` | `curlimages/curl:8.6.0` | benign traffic generator |
+| `pathogen-ns` | `pathogen` | `log4j-chain-attacker@sha256:c4dd5f…` | serves the LDAP Specimen (disease origin) |
+
+Plus the **user-defined SBoBs** (`sbobs/*-ap.yaml`, `*-nn.yaml`) — the
+ApplicationProfile + NetworkNeighborhood for each java-poc workload, carrying
+`kubescape.io/managed-by: User` + `completion: complete`. These are what make the
+detection bind to a User profile (the calibration relies on `backend` being
+SBoB-bound).
+
+## Naming convention (medical vocabulary)
+
+- app namespace `java-poc`, pathogen namespace `pathogen-ns`
+- workloads `backend` / `frontend` / `observer` / `postgres` / `pathogen`
+- **image names stay literal** (`log4j-chain-*`) — they are external wire, digest-pinned.
+
+The `TestJavaPocCalibration` config defaults (`appNS=java-poc`, `backend`,
+`pathogenNS=pathogen-ns`, `pathogen`) match these names exactly, so the e2e suite
+needs no overrides.
+
+## Deploy
+
+```bash
+skaffold deploy -m java-poc-apps -p k3s      # from this dir
+# or plain kubectl, in the same order:
+kubectl apply -f 00-namespaces.yaml -f sbobs/ -f 10-postgres.yaml \
+  -f 20-frontend.yaml -f 30-backend.yaml -f 40-observer.yaml -f 50-pathogen.yaml
+```
+
+**Order is load-bearing:** namespaces → SBoBs → workloads. A User SBoB must exist
+*before* the pod starts, or the node-agent binds a learnt sibling profile instead.
+If a pod started before its SBoB (e.g. CRDs not yet ready), `kubectl delete pod`
+it to rebind — do **not** `rollout restart` (that clobbers the managed-by
+annotation).
+
+## Layering
+
+This is **only the apps**. It assumes the detection/forensics stack (kubescape +
+CRDs, vector, ClickHouse, dx) is already deployed — that is the **soc** repo's
+Skaffold. Compose them: soc stack first, then these apps, then Pixie's native
+Skaffold. k3s only for now.
+
+## Pinning status
+
+Custom images are digest-pinned. Stock images (`nginx`, `postgres`, `curl`) are
+tag-pinned here; digest-pin them as part of the fully-pinned Skaffold work
+(soc #230).

--- a/example/java-poc/sbobs/backend-ap.yaml
+++ b/example/java-poc/sbobs/backend-ap.yaml
@@ -1,0 +1,200 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: backend
+    kubescape.io/workload-namespace: java-poc
+  name: backend
+  namespace: java-poc
+spec:
+  architectures:
+    - amd64
+  containers:
+    - capabilities: []
+      endpoints:
+        - direction: inbound
+          endpoint: :8080/api/products
+          internal: true
+          methods:
+            - GET
+        - direction: inbound
+          endpoint: :8080/api/login
+          internal: true
+          methods:
+            - POST
+        - direction: inbound
+          endpoint: :8080/healthz
+          internal: true
+          methods:
+            - GET
+      execs:
+        - args:
+            - /opt/java/openjdk/bin/java
+            - -jar
+            - /app/app.jar
+          path: /opt/java/openjdk/bin/java
+        - args:
+            - /usr/bin/java
+            - -jar
+            - /app/app.jar
+          path: /usr/bin/java
+        - args:
+            - /usr/bin/curl
+          path: /usr/bin/curl
+        - args:
+            - /usr/bin/psql
+          path: /usr/bin/psql
+      imageID: ghcr.io/k8sstormcenter/log4j-backend-vulnerable@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      imageTag: ghcr.io/k8sstormcenter/log4j-backend-vulnerable:latest
+      name: backend
+      opens:
+        - flags:
+            - O_RDONLY
+          path: /app/app.jar
+        - flags:
+            - O_RDONLY
+          path: /etc/localtime
+        - flags:
+            - O_RDONLY
+          path: /etc/resolv.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/hosts
+        - flags:
+            - O_RDONLY
+          path: /etc/nsswitch.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/host.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/passwd
+        - flags:
+            - O_RDONLY
+          path: /etc/group
+        - flags:
+            - O_RDONLY
+          path: /opt/java/openjdk/lib
+        - flags:
+            - O_RDONLY
+          path: /opt/java/openjdk/conf
+        - flags:
+            - O_RDONLY
+          path: /usr/lib/jvm
+        - flags:
+            - O_RDWR
+            - O_CREAT
+          path: /tmp
+        - flags:
+            - O_RDONLY
+          path: /proc/sys/net
+        - flags:
+            - O_RDONLY
+          path: /app/BOOT-INF/lib
+        - flags:
+            - O_RDONLY
+          path: /opt/java/openjdk/conf/jndi.properties
+        - flags:
+            - O_RDONLY
+          path: /root/.pgpass
+        - flags:
+            - O_RDONLY
+          path: /usr/lib/x86_64-linux-gnu/perl-base/Symbol.pm
+        - flags:
+            - O_RDONLY
+          path: /usr/lib/x86_64-linux-gnu/perl-base/IPC/Open3.pm
+        - flags:
+            - O_RDONLY
+          path: /usr/lib/x86_64-linux-gnu/perl-base/constant.pm
+        - flags:
+            - O_RDONLY
+          path: /usr/share/perl5/PgCommon.pm
+        - flags:
+            - O_RDONLY
+          path: /usr/share/coreutils/locales/en-US.ftl
+        - flags:
+            - O_RDONLY
+          path: /usr/share/coreutils/locales/head/en-US.ftl
+        - flags:
+            - O_RDONLY
+          path: /usr/share/coreutils/locales/env/en-US.ftl
+      rulePolicies:
+        R0002:
+          processAllowed:
+            - px_jattach
+            - Attach Listener
+            - C1 CompilerThre
+            - reservoir CompilerThre
+            - runc:[1:INIT]
+            - runc:[2:INIT]
+            - runc:[3:INIT]
+        R0004:
+          processAllowed:
+            - runc:[1:INIT]
+            - runc:[2:INIT]
+            - runc:[3:INIT]
+      seccompProfile:
+        spec:
+          defaultAction: ""
+      syscalls:
+        - accept
+        - accept4
+        - bind
+        - brk
+        - clone
+        - close
+        - connect
+        - epoll_create1
+        - epoll_ctl
+        - epoll_pwait
+        - epoll_wait
+        - execve
+        - exit
+        - exit_group
+        - fcntl
+        - fstat
+        - futex
+        - getpeername
+        - getsockname
+        - getsockopt
+        - gettid
+        - getuid
+        - ioctl
+        - listen
+        - mmap
+        - mprotect
+        - munmap
+        - newfstatat
+        - openat
+        - poll
+        - prctl
+        - pread64
+        - pwrite64
+        - read
+        - readlink
+        - recvfrom
+        - recvmsg
+        - rt_sigaction
+        - rt_sigprocmask
+        - rt_sigreturn
+        - sched_yield
+        - sendfile
+        - sendto
+        - set_robust_list
+        - setsockopt
+        - sigaltstack
+        - socket
+        - stat
+        - statx
+        - tgkill
+        - write
+        - writev
+  ephemeralContainers: []
+  initContainers: []

--- a/example/java-poc/sbobs/backend-nn.yaml
+++ b/example/java-poc/sbobs/backend-nn.yaml
@@ -1,0 +1,81 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: backend
+    kubescape.io/workload-namespace: java-poc
+  name: backend
+  namespace: java-poc
+spec:
+  containers:
+    - egress:
+        - dns: ""
+          dnsNames: null
+          identifier: egress-kube-dns
+          ipAddress: ""
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+          ports:
+            - name: UDP-53
+              port: 53
+              protocol: UDP
+            - name: TCP-53
+              port: 53
+              protocol: TCP
+          type: internal
+        - dns: ""
+          dnsNames: null
+          identifier: egress-postgres
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: postgres
+          ports:
+            - name: TCP-5432
+              port: 5432
+              protocol: TCP
+          type: internal
+      ingress:
+        - dns: ""
+          dnsNames: null
+          identifier: ingress-from-frontend
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: frontend
+          ports:
+            - name: TCP-8080
+              port: 8080
+              protocol: TCP
+          type: internal
+        - dns: ""
+          dnsNames: null
+          identifier: ingress-from-observer
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: observer
+          ports:
+            - name: TCP-8080
+              port: 8080
+              protocol: TCP
+          type: internal
+      name: backend
+  ephemeralContainers: []
+  initContainers: []
+  matchLabels:
+    app: backend

--- a/example/java-poc/sbobs/frontend-ap.yaml
+++ b/example/java-poc/sbobs/frontend-ap.yaml
@@ -1,0 +1,123 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: frontend
+    kubescape.io/workload-namespace: java-poc
+  name: frontend
+  namespace: java-poc
+spec:
+  architectures:
+    - amd64
+  containers:
+    - capabilities:
+        - CAP_CHOWN
+        - CAP_DAC_OVERRIDE
+        - CAP_NET_BIND_SERVICE
+        - CAP_SETGID
+        - CAP_SETUID
+      endpoints:
+        - direction: inbound
+          endpoint: :8080/api/products
+          internal: false
+          methods:
+            - GET
+        - direction: inbound
+          endpoint: :8080/api/login
+          internal: false
+          methods:
+            - POST
+        - direction: inbound
+          endpoint: :8080/healthz
+          internal: false
+          methods:
+            - GET
+      execs:
+        - args:
+            - nginx
+            - -g
+            - daemon off;
+          path: /usr/sbin/nginx
+      imageID: docker.io/library/nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      imageTag: docker.io/library/nginx:stable-alpine
+      name: nginx
+      opens:
+        - flags:
+            - O_RDONLY
+          path: /etc/nginx/nginx.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/nginx/conf.d
+        - flags:
+            - O_RDONLY
+          path: /etc/nginx/mime.types
+        - flags:
+            - O_RDONLY
+          path: /etc/resolv.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/hosts
+        - flags:
+            - O_RDONLY
+          path: /etc/nsswitch.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/localtime
+        - flags:
+            - O_WRONLY
+            - O_APPEND
+            - O_CREAT
+          path: /var/log/nginx
+        - flags:
+            - O_RDWR
+            - O_CREAT
+          path: /var/cache/nginx
+        - flags:
+            - O_WRONLY
+            - O_CREAT
+          path: /run/nginx.pid
+      rulePolicies: {}
+      seccompProfile:
+        spec:
+          defaultAction: ""
+      syscalls:
+        - accept4
+        - bind
+        - brk
+        - close
+        - connect
+        - epoll_create1
+        - epoll_ctl
+        - epoll_pwait
+        - epoll_wait
+        - exit_group
+        - fcntl
+        - fstat
+        - futex
+        - getsockname
+        - getsockopt
+        - listen
+        - mmap
+        - mprotect
+        - munmap
+        - newfstatat
+        - openat
+        - read
+        - recvfrom
+        - rt_sigaction
+        - rt_sigprocmask
+        - sendto
+        - setsockopt
+        - socket
+        - statx
+        - write
+        - writev
+  ephemeralContainers: []
+  initContainers: []

--- a/example/java-poc/sbobs/frontend-nn.yaml
+++ b/example/java-poc/sbobs/frontend-nn.yaml
@@ -1,0 +1,66 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: frontend
+    kubescape.io/workload-namespace: java-poc
+  name: frontend
+  namespace: java-poc
+spec:
+  containers:
+    - egress:
+        - dns: ""
+          dnsNames: null
+          identifier: egress-kube-dns
+          ipAddress: ""
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+          ports:
+            - name: UDP-53
+              port: 53
+              protocol: UDP
+            - name: TCP-53
+              port: 53
+              protocol: TCP
+          type: internal
+        - dns: ""
+          dnsNames: null
+          identifier: egress-backend
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: backend
+          ports:
+            - name: TCP-8080
+              port: 8080
+              protocol: TCP
+          type: internal
+      ingress:
+        - dns: ""
+          dnsNames: null
+          identifier: ingress-external
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector: null
+          ports:
+            - name: TCP-8080
+              port: 8080
+              protocol: TCP
+          type: external
+      name: nginx
+  ephemeralContainers: []
+  initContainers: []
+  matchLabels:
+    app: frontend

--- a/example/java-poc/sbobs/observer-ap.yaml
+++ b/example/java-poc/sbobs/observer-ap.yaml
@@ -1,0 +1,97 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: observer
+    kubescape.io/workload-namespace: java-poc
+  name: observer
+  namespace: java-poc
+spec:
+  architectures:
+    - amd64
+  containers:
+    - capabilities: []
+      endpoints: []
+      execs:
+        - args:
+            - /usr/bin/curl
+            - -s
+            - http://frontend:8080/api/products
+          path: /usr/bin/curl
+        - args:
+            - /bin/sleep
+            - "30"
+          path: /bin/sleep
+        - args:
+            - /bin/sh
+            - -c
+          path: /bin/sh
+      imageID: docker.io/curlimages/curl@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      imageTag: docker.io/curlimages/curl:8.5.0
+      name: observer
+      opens:
+        - flags:
+            - O_RDONLY
+          path: /etc/resolv.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/hosts
+        - flags:
+            - O_RDONLY
+          path: /etc/nsswitch.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/ssl/certs/ca-certificates.crt
+        - flags:
+            - O_RDONLY
+          path: /etc/localtime
+        - flags:
+            - O_RDONLY
+          path: /etc/passwd
+      rulePolicies: {}
+      seccompProfile:
+        spec:
+          defaultAction: ""
+      syscalls:
+        - arch_prctl
+        - bind
+        - brk
+        - clone
+        - close
+        - connect
+        - execve
+        - exit
+        - exit_group
+        - fcntl
+        - fstat
+        - futex
+        - getsockname
+        - getsockopt
+        - gettid
+        - getuid
+        - mmap
+        - mprotect
+        - munmap
+        - nanosleep
+        - newfstatat
+        - openat
+        - poll
+        - read
+        - recvfrom
+        - rt_sigaction
+        - rt_sigprocmask
+        - rt_sigreturn
+        - sendto
+        - setsockopt
+        - socket
+        - statx
+        - write
+  ephemeralContainers: []
+  initContainers: []

--- a/example/java-poc/sbobs/observer-nn.yaml
+++ b/example/java-poc/sbobs/observer-nn.yaml
@@ -1,0 +1,55 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: observer
+    kubescape.io/workload-namespace: java-poc
+  name: observer
+  namespace: java-poc
+spec:
+  containers:
+    - egress:
+        - dns: ""
+          dnsNames: null
+          identifier: egress-kube-dns
+          ipAddress: ""
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+          ports:
+            - name: UDP-53
+              port: 53
+              protocol: UDP
+            - name: TCP-53
+              port: 53
+              protocol: TCP
+          type: internal
+        - dns: ""
+          dnsNames: null
+          identifier: egress-frontend
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: frontend
+          ports:
+            - name: TCP-8080
+              port: 8080
+              protocol: TCP
+          type: internal
+      ingress: []
+      name: observer
+  ephemeralContainers: []
+  initContainers: []
+  matchLabels:
+    app: observer

--- a/example/java-poc/sbobs/postgres-ap.yaml
+++ b/example/java-poc/sbobs/postgres-ap.yaml
@@ -1,0 +1,154 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: postgres
+    kubescape.io/workload-namespace: java-poc
+  name: postgres
+  namespace: java-poc
+spec:
+  architectures:
+    - amd64
+  containers:
+    - capabilities:
+        - CAP_CHOWN
+        - CAP_DAC_OVERRIDE
+        - CAP_DAC_READ_SEARCH
+        - CAP_FOWNER
+        - CAP_FSETID
+        - CAP_KILL
+        - CAP_SETGID
+        - CAP_SETUID
+      endpoints:
+        - direction: inbound
+          endpoint: :5432/
+          internal: true
+          methods: []
+      execs:
+        - args:
+            - postgres
+          path: /usr/lib/postgresql/16/bin/postgres
+        - args:
+            - initdb
+          path: /usr/lib/postgresql/16/bin/initdb
+        - args:
+            - /usr/local/bin/docker-entrypoint.sh
+            - postgres
+          path: /usr/local/bin/docker-entrypoint.sh
+        - args:
+            - /usr/bin/psql
+          path: /usr/bin/psql
+        - args:
+            - pg_isready
+          path: /usr/lib/postgresql/16/bin/pg_isready
+      imageID: docker.io/library/postgres@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      imageTag: docker.io/library/postgres:16
+      name: postgres
+      opens:
+        - flags:
+            - O_RDWR
+            - O_CREAT
+          path: /var/lib/postgresql/data
+        - flags:
+            - O_RDONLY
+          path: /etc/passwd
+        - flags:
+            - O_RDONLY
+          path: /etc/group
+        - flags:
+            - O_RDONLY
+          path: /etc/resolv.conf
+        - flags:
+            - O_RDONLY
+          path: /etc/hosts
+        - flags:
+            - O_RDONLY
+          path: /etc/localtime
+        - flags:
+            - O_RDONLY
+          path: /etc/nsswitch.conf
+        - flags:
+            - O_RDONLY
+          path: /usr/share/postgresql
+        - flags:
+            - O_RDONLY
+          path: /docker-entrypoint-initdb.d
+        - flags:
+            - O_RDWR
+            - O_CREAT
+          path: /tmp
+        - flags:
+            - O_RDWR
+            - O_CREAT
+          path: /var/run/postgresql
+      rulePolicies: {}
+      seccompProfile:
+        spec:
+          defaultAction: ""
+      syscalls:
+        - accept
+        - bind
+        - brk
+        - chown
+        - clone
+        - close
+        - connect
+        - dup2
+        - epoll_create1
+        - epoll_ctl
+        - epoll_wait
+        - execve
+        - exit
+        - exit_group
+        - fchown
+        - fcntl
+        - fdatasync
+        - fork
+        - fstat
+        - fsync
+        - futex
+        - getpeername
+        - getpid
+        - getrusage
+        - getsockname
+        - getsockopt
+        - kill
+        - lseek
+        - mmap
+        - mprotect
+        - munmap
+        - newfstatat
+        - openat
+        - poll
+        - pread64
+        - pwrite64
+        - read
+        - readlink
+        - recvfrom
+        - rename
+        - rt_sigaction
+        - rt_sigprocmask
+        - rt_sigreturn
+        - select
+        - sendto
+        - setsid
+        - setsockopt
+        - shmat
+        - socket
+        - stat
+        - statfs
+        - statx
+        - umask
+        - unlink
+        - wait4
+        - write
+        - writev
+  ephemeralContainers: []
+  initContainers: []

--- a/example/java-poc/sbobs/postgres-nn.yaml
+++ b/example/java-poc/sbobs/postgres-nn.yaml
@@ -1,0 +1,55 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: postgres
+    kubescape.io/workload-namespace: java-poc
+  name: postgres
+  namespace: java-poc
+spec:
+  containers:
+    - egress:
+        - dns: ""
+          dnsNames: null
+          identifier: egress-kube-dns
+          ipAddress: ""
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+          ports:
+            - name: UDP-53
+              port: 53
+              protocol: UDP
+            - name: TCP-53
+              port: 53
+              protocol: TCP
+          type: internal
+      ingress:
+        - dns: ""
+          dnsNames: null
+          identifier: ingress-from-backend
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: backend
+          ports:
+            - name: TCP-5432
+              port: 5432
+              protocol: TCP
+          type: internal
+      name: postgres
+  ephemeralContainers: []
+  initContainers: []
+  matchLabels:
+    app: postgres

--- a/example/java-poc/skaffold.yaml
+++ b/example/java-poc/skaffold.yaml
@@ -1,0 +1,51 @@
+# Golden source: the java-poc test apps (log4j chain + pathogen) for the SOC e2e suite.
+#
+# This Skaffold deploys ONLY the sample workloads and their user-defined SBoBs.
+# It assumes the detection/forensics stack (kubescape + its CRDs, vector,
+# ClickHouse, dx) is already present — that is the soc repo's Skaffold. The two
+# compose: soc stack first, then these apps.
+#
+# Deploy order matters: namespaces -> SBoBs -> workloads. A user-defined
+# ApplicationProfile/NetworkNeighborhood must EXIST before the pod starts, or the
+# node-agent binds a learnt sibling profile instead (never the User one). The
+# rawYaml list below is applied in order so the SBoBs land first.
+#
+#   skaffold deploy -m java-poc-apps -p k3s
+#
+# Images are prebuilt (ghcr.io/k8sstormcenter/log4j-chain-*), so this config only
+# deploys — it never builds.
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: java-poc-apps
+manifests:
+  rawYaml:
+    # 1) namespaces
+    - 00-namespaces.yaml
+    # 2) user-defined SBoBs (must precede the pods they bind)
+    - sbobs/backend-ap.yaml
+    - sbobs/backend-nn.yaml
+    - sbobs/frontend-ap.yaml
+    - sbobs/frontend-nn.yaml
+    - sbobs/observer-ap.yaml
+    - sbobs/observer-nn.yaml
+    - sbobs/postgres-ap.yaml
+    - sbobs/postgres-nn.yaml
+    # 3) workloads
+    - 10-postgres.yaml
+    - 20-frontend.yaml
+    - 30-backend.yaml
+    - 40-observer.yaml
+    - 50-pathogen.yaml
+deploy:
+  kubectl:
+    # SBoBs are CRs whose readiness Skaffold can't infer; only wait on the apps.
+    defaultNamespace: ""
+profiles:
+  # k3s is the only supported target for now (flannel + hostPort assumptions live
+  # in the soc stack). Kept as an explicit profile so cloud targets can be added
+  # later without changing the default invocation.
+  - name: k3s
+    deploy:
+      kubectl:
+        defaultNamespace: ""


### PR DESCRIPTION
## Why

The SOC e2e / calibration suite (pixie fork [#68](https://github.com/k8sstormcenter/pixie/pull/68), `src/e2e_test/adaptive_export_loadtest`, `TestJavaPocCalibration`) drives the java-poc log4j chain, but the medically-named, digest-pinned manifests it targets existed **nowhere on disk** — applied inline per-rig. The on-disk copies under `example/log4j-chain/` use older `log4j-poc`/`chain-*`/`attacker-ns` naming and have drifted (observer image, postgres version), making e2e runs non-reproducible.

## What

New `example/java-poc/` — the **single source of truth** for the test apps, captured from the working deployment:

| Namespace | Workloads |
|---|---|
| `java-poc` | `backend` (vulnerable, scenario A), `frontend`, `postgres`, `observer` |
| `pathogen-ns` | `pathogen` (serves the LDAP Specimen) |

Plus `sbobs/` — user-defined ApplicationProfile + NetworkNeighborhood per workload (`kubescape.io/managed-by: User`), the binding the calibration relies on.

`skaffold.yaml` deploys **namespaces → SBoBs → workloads** (order is load-bearing: a User SBoB must exist before the pod starts). k3s only.

- Medical naming matches the e2e test config defaults exactly — zero test overrides.
- Custom images digest-pinned; image names stay literal (`log4j-chain-*`).
- `example/log4j-chain/` left untouched (its CI keeps `chain-*`).

## Scope

Consolidation base with pixie [#68](https://github.com/k8sstormcenter/pixie/pull/68). No new features — golden-source consolidation for reproducible testing.