### PR TITLE
fix(java-poc): real postgres-backed backend (#151 product-API image + products seed)

### DIFF
--- a/example/java-poc/10-postgres.yaml
+++ b/example/java-poc/10-postgres.yaml
@@ -1,20 +1,67 @@
 apiVersion: v1
 data:
   seed.sql: |
-    CREATE TABLE users (
-        id SERIAL PRIMARY KEY,
-        email TEXT,
-        full_name TEXT,
-        created_at TIMESTAMP DEFAULT NOW()
+    -- fusioncore shop schema + seed. Loaded by postgres via /docker-entrypoint-initdb.d.
+    -- Normal backend traffic (App.java) reads products/users and writes orders on every
+    -- request, so the chain baseline has a steady backend→postgres edge. The JNDI exfil
+    -- (psql from /bin/sh) then blends into that DB traffic at the network layer, while the
+    -- process spawn (/bin/sh, psql) stays the Scenario-A R0001 tell.
+
+    CREATE TABLE IF NOT EXISTS products (
+        id          SERIAL PRIMARY KEY,
+        name        TEXT NOT NULL,
+        sku         TEXT UNIQUE NOT NULL,
+        category    TEXT NOT NULL,
+        price_cents INT  NOT NULL,
+        stock       INT  NOT NULL DEFAULT 100,
+        description TEXT
     );
-    INSERT INTO users (email, full_name) VALUES
-        ('alice@example.com', 'Alice Anderson'),
-        ('bob@example.com',   'Bob Brown'),
-        ('carol@example.com', 'Carol Carter');
+
+    INSERT INTO products (name, sku, category, price_cents, stock, description) VALUES
+        ('Widget',          'WID-001', 'widgets',  999,   250, 'A reliable everyday widget'),
+        ('Widget Pro',      'WID-002', 'widgets',  1999,  120, 'The widget, but pro'),
+        ('Mega Widget',     'WID-003', 'widgets',  3499,  40,  'Industrial-grade widget'),
+        ('Gadget',          'GAD-001', 'gadgets',  1499,  200, 'A handy gadget'),
+        ('Gadget Mini',     'GAD-002', 'gadgets',  799,   300, 'Pocket-sized gadget'),
+        ('Smart Gadget',    'GAD-003', 'gadgets',  4999,  60,  'Gadget with a chip in it'),
+        ('Thingamajig',     'THI-001', 'tools',    1299,  150, 'When you need a thingamajig'),
+        ('Doohickey',       'DOO-001', 'tools',    599,   500, 'Cheap and cheerful doohickey'),
+        ('Sprocket',        'SPR-001', 'parts',    349,   900, 'Toothed sprocket, 12T'),
+        ('Cog',             'COG-001', 'parts',    249,   900, 'Replacement cog'),
+        ('Flux Capacitor',  'FLX-001', 'specials', 99999, 3,   'Makes time travel possible'),
+        ('Bobblehead',      'BOB-001', 'specials', 1599,  75,  'Limited edition bobblehead')
+    ON CONFLICT (sku) DO NOTHING;
+
+    CREATE TABLE IF NOT EXISTS users (
+        id            SERIAL PRIMARY KEY,
+        email         TEXT UNIQUE NOT NULL,
+        full_name     TEXT,
+        password_hash TEXT,
+        created_at    TIMESTAMP DEFAULT NOW()
+    );
+
+    INSERT INTO users (email, full_name, password_hash) VALUES
+        ('alice@example.com', 'Alice Anderson', 'x'),
+        ('bob@example.com',   'Bob Brown',      'x'),
+        ('carol@example.com', 'Carol Carter',   'x'),
+        ('dave@example.com',  'Dave Davis',     'x'),
+        ('erin@example.com',  'Erin Edwards',   'x')
+    ON CONFLICT (email) DO NOTHING;
+
+    CREATE TABLE IF NOT EXISTS orders (
+        id          SERIAL PRIMARY KEY,
+        user_email  TEXT,
+        total_cents INT,
+        items       TEXT,
+        created_at  TIMESTAMP DEFAULT NOW()
+    );
+
+    GRANT ALL ON ALL TABLES IN SCHEMA public TO postgres;
 kind: ConfigMap
 metadata:
   name: pg-seed
   namespace: java-poc
+---
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/example/java-poc/30-backend.yaml
+++ b/example/java-poc/30-backend.yaml
@@ -33,9 +33,15 @@ spec:
               value: appdb
             - name: POSTGRES_USER
               value: postgres
+            # JNDI/_probe call-out target — pathogen-ns for the java-poc naming
+            # (the log4shell disease itself is driven by the malicious User-Agent).
+            - name: LDAP_HOST
+              value: pathogen.pathogen-ns.svc.cluster.local
             - name: JAVA_TOOL_OPTIONS
               value: -Dnetworkaddress.cache.negative.ttl=0 -Dnetworkaddress.cache.ttl=5
-          image: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:72655e5a5523f578f99544ba7514aeb067f219d09811ea77235dba8bcb6cefb5
+          # #151 product-API backend: real backend->postgres pg-wire on /api/products
+          # (the stub 72655e returned {"products":[]} and never opened a pg connection).
+          image: ghcr.io/k8sstormcenter/log4j-chain-backend-vulnerable@sha256:689e1c1b29083b43845302f59e7f1706b7a0bf1ed825395ae4421fda957afcfd
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/example/java-poc/60-cleannoise.yaml
+++ b/example/java-poc/60-cleannoise.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cleannoise
+  name: cleannoise
+  namespace: java-poc
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: cleannoise
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: cleannoise
+        kubescape.io/user-defined-network: cleannoise
+        kubescape.io/user-defined-profile: cleannoise
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - while true; do wget -qO- http://'frontend.java-poc.svc.cluster.local:8080'/api/products?q=noise >/dev/null 2>&1; wget -qO- http://'frontend.java-poc.svc.cluster.local:8080'/ >/dev/null 2>&1; sleep 0.3; done
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          name: busybox
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/example/java-poc/README.md
+++ b/example/java-poc/README.md
@@ -15,6 +15,7 @@ This dir captures the exact working, medically-named, digest-pinned deployment.
 | `java-poc` | `frontend` | `nginx:1.27-alpine` | edge |
 | `java-poc` | `postgres` | `postgres:16` | app DB (PII the disease hemorrhages) |
 | `java-poc` | `observer` | `curlimages/curl:8.6.0` | benign traffic generator |
+| `java-poc` | `cleannoise` | `busybox:1.36` | benign noise (x3) → frontend `/api/products?q=noise`; a true-negative in the confusion matrix |
 | `pathogen-ns` | `pathogen` | `log4j-chain-attacker@sha256:c4dd5f…` | serves the LDAP Specimen (disease origin) |
 
 Plus the **user-defined SBoBs** (`sbobs/*-ap.yaml`, `*-nn.yaml`) — the

--- a/example/java-poc/sbobs/cleannoise-ap.yaml
+++ b/example/java-poc/sbobs/cleannoise-ap.yaml
@@ -1,0 +1,87 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ApplicationProfile
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: cleannoise
+    kubescape.io/workload-namespace: java-poc
+  name: cleannoise
+  namespace: java-poc
+spec:
+  architectures:
+    - amd64
+  containers:
+    - capabilities: []
+      endpoints: []
+      execs:
+        - args:
+            - /bin/sh
+            - -c
+          path: /bin/sh
+        - args:
+            - /bin/busybox
+            - wget
+          path: /bin/busybox
+        - args:
+            - /bin/wget
+          path: /bin/wget
+        - args:
+            - /bin/sleep
+            - "0.3"
+          path: /bin/sleep
+      imageID: docker.io/library/busybox@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      imageTag: docker.io/library/busybox:1.36
+      name: busybox
+      opens:
+        - flags: [O_RDONLY]
+          path: /etc/resolv.conf
+        - flags: [O_RDONLY]
+          path: /etc/hosts
+        - flags: [O_RDONLY]
+          path: /etc/nsswitch.conf
+      rulePolicies: {}
+      seccompProfile:
+        spec:
+          defaultAction: ""
+      syscalls:
+        - arch_prctl
+        - bind
+        - brk
+        - clone
+        - close
+        - connect
+        - execve
+        - exit
+        - exit_group
+        - fcntl
+        - fstat
+        - futex
+        - getsockname
+        - getsockopt
+        - gettid
+        - getuid
+        - mmap
+        - mprotect
+        - munmap
+        - nanosleep
+        - newfstatat
+        - openat
+        - poll
+        - read
+        - recvfrom
+        - rt_sigaction
+        - rt_sigprocmask
+        - rt_sigreturn
+        - sendto
+        - setsockopt
+        - socket
+        - statx
+        - write
+  ephemeralContainers: []
+  initContainers: []

--- a/example/java-poc/sbobs/cleannoise-nn.yaml
+++ b/example/java-poc/sbobs/cleannoise-nn.yaml
@@ -1,0 +1,39 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  annotations:
+    kubescape.io/completion: complete
+    kubescape.io/managed-by: User
+    kubescape.io/resource-size: "1"
+    kubescape.io/status: completed
+    kubescape.io/sync-checksum: e9969f6823aaa51aa5c970d1f00f079e08418b79453c66664e0f6bc82b696083
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: cleannoise
+    kubescape.io/workload-namespace: java-poc
+  name: cleannoise
+  namespace: java-poc
+spec:
+  containers:
+    - egress:
+        - dns: ""
+          dnsNames: null
+          identifier: 3406f049084b16f5b0234d3140fcf1d3fe5f6e8a1601d90a62456a510c1e0705
+          ipAddress: ""
+          namespaceSelector: null
+          podSelector:
+            matchLabels:
+              app: frontend
+          ports:
+            - name: TCP-80
+              port: 80
+              protocol: TCP
+          type: internal
+      ingress: null
+      name: busybox
+  ephemeralContainers: null
+  initContainers: null
+  matchLabels:
+    app: cleannoise

--- a/example/java-poc/skaffold.yaml
+++ b/example/java-poc/skaffold.yaml
@@ -31,12 +31,15 @@ manifests:
     - sbobs/observer-nn.yaml
     - sbobs/postgres-ap.yaml
     - sbobs/postgres-nn.yaml
+    - sbobs/cleannoise-ap.yaml
+    - sbobs/cleannoise-nn.yaml
     # 3) workloads
     - 10-postgres.yaml
     - 20-frontend.yaml
     - 30-backend.yaml
     - 40-observer.yaml
     - 50-pathogen.yaml
+    - 60-cleannoise.yaml
 deploy:
   kubectl:
     # SBoBs are CRs whose readiness Skaffold can't infer; only wait on the apps.


### PR DESCRIPTION
The golden `example/java-poc/` was captured from a rig running the **pre-#151 stub** backend, so it shipped two regressions:

1. **Stub image** `@sha256:72655e…` — `ProductHandler` returns `{"products":[]}` and **never opens a postgres connection** (the "zero pg-wire / psql-not-in-pixie" incident #151 fixed).
2. **users-only seed** — no `products` table, so `/api/products` errors and the observer's `curl -sf /api/products` fails (the "only 505s").

## Fix
- **backend image → the #151 product-API build** `@sha256:689e1c1b…` (`:latest` = merge `e47f8a8`). Verified live: `/api/products` returns the seeded products (Widget/Widget Pro/Mega Widget), `/api/_probe` = 200, startup logs `db=jdbc:postgresql://postgres:5432/appdb`.
- **pg-seed → the #151 `products`/`users`/`orders` schema+seed** (from `example/log4j-chain/postgres/seed.sql`).
- **`LDAP_HOST=pathogen.pathogen-ns`** for the java-poc naming.

The `skaffold.yaml` deploys these via `rawYaml`, so a fresh `skaffold deploy -m java-poc-apps` stands up a backend that actually talks to postgres with the right tables.

## Note on Pixie capture
The app-level connection is real (products served). Pixie `pgsql_events`/`conn_stats` visibility of it is attach-timing-dependent — the JDBC pool opens at pod boot before Pixie's probes attach, so pooled connections recycle into the trace over time / under load (HTTP shows immediately, being new-connection-per-request). Not a manifest issue.

Refs bob #151, #152, pixie #68.