### PR TITLE
fix(java-poc): bounce app pods after deploy so they bind their User SBoBs

### DIFF
--- a/example/java-poc/skaffold.yaml
+++ b/example/java-poc/skaffold.yaml
@@ -44,6 +44,28 @@ deploy:
   kubectl:
     # SBoBs are CRs whose readiness Skaffold can't infer; only wait on the apps.
     defaultNamespace: ""
+    hooks:
+      after: &sbob-bind-bounce
+        # A User SBoB must be registered by the kubescape node-agent BEFORE the pod
+        # it binds starts — else the node-agent binds a *learnt* sibling profile and
+        # the User profile is never enforced (no R0001 on deviation). rawYaml applies
+        # the SBoBs and workloads together, so the pods race ahead of SBoB
+        # registration. After deploy, once node-agent is Ready, bounce the app pods
+        # (delete — NOT rollout restart, which clobbers the managed-by:User annotation)
+        # so the fresh pods bind the now-registered User SBoBs.
+        - host:
+            command:
+              - bash
+              - -c
+              - |
+                set -e
+                kubectl -n honey rollout status ds/node-agent --timeout=180s 2>/dev/null || true
+                for w in backend frontend observer postgres cleannoise; do
+                  kubectl -n java-poc delete pod -l app="$w" --ignore-not-found --wait=false 2>/dev/null || true
+                done
+                kubectl -n pathogen-ns delete pod -l app=pathogen --ignore-not-found --wait=false 2>/dev/null || true
+                echo "bounced java-poc + pathogen pods to bind their User SBoBs"
+            os: [linux, darwin]
 profiles:
   # k3s is the only supported target for now (flannel + hostPort assumptions live
   # in the soc stack). Kept as an explicit profile so cloud targets can be added
@@ -52,3 +74,5 @@ profiles:
     deploy:
       kubectl:
         defaultNamespace: ""
+        hooks:
+          after: *sbob-bind-bounce


### PR DESCRIPTION
## Problem
The `java-poc` skaffold applies the SBoBs (`sbobs/*-ap.yaml`, `*-nn.yaml`) and the workloads in the same `rawYaml` pass, so the app pods often start **before** the kubescape node-agent has registered the User `ApplicationProfile`. The node-agent then binds a *learnt* sibling profile, the User profile is never enforced, and a deviating spawn produces **no R0001** — the calibration's `stage1/kubescape-detects` never fires.

## Fix
A skaffold **deploy after-hook** (in the base and the `k3s` profile, shared via a YAML anchor): wait for the `node-agent` DaemonSet to be Ready, then `kubectl delete pod` the java-poc + pathogen app pods (**delete**, not `rollout restart`, which clobbers the `managed-by:User` annotation) so the fresh pods bind the now-registered SBoBs.

## Verified live (fresh rig)
After the bounce, all 5 workloads log `container has a user defined profile` (backend/frontend/observer/postgres/cleannoise), and a backend spawn (`sh -c 'id; cat /etc/shadow; wget …'`) fires **R0001 ×5** ("Unexpected process launched") **+ R0010** ("Unexpected sensitive file access: /etc/shadow") against the enforced `backend` profile (`failOnProfile:true`).

Refs pixie #68 (calibration stage-1), bob #152/#154.