### PR TITLE
chore(log4j-sbobs): wildcard opens to allowlist benign startup file access

### DIFF
--- a/_artifacts/log4j-sbobs/cp-chain-backend.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-backend.yaml
@@ -100,6 +100,36 @@ spec:
   - path: /usr/share/coreutils/locales/env/en-US.ftl
     flags:
     - O_RDONLY
+  - path: /opt/java/openjdk/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.cache
+    flags:
+    - O_RDONLY
+  - path: /etc/krb5/*
+    flags:
+    - O_RDONLY
+  - path: /etc/gss/*
+    flags:
+    - O_RDONLY
+  - path: /etc/locale.alias
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl/*
+    flags:
+    - O_RDONLY
+  - path: /opt/java/openjdk
+    flags:
+    - O_RDONLY
+  - path: /etc/krb5
+    flags:
+    - O_RDONLY
+  - path: /etc/gss
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl
+    flags:
+    - O_RDONLY
   seccompProfile:
     spec:
       defaultAction: ''

--- a/_artifacts/log4j-sbobs/cp-chain-frontend.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-frontend.yaml
@@ -55,6 +55,72 @@ spec:
     flags:
     - O_WRONLY
     - O_CREAT
+  - path: /var/lib/dpkg/*
+    flags:
+    - O_RDONLY
+  - path: /var/lib/apt/*
+    flags:
+    - O_RDONLY
+  - path: /etc/apt/*
+    flags:
+    - O_RDONLY
+  - path: /etc/dpkg/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ca-certificates/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.conf.d/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.cache
+    flags:
+    - O_RDONLY
+  - path: /usr/local/share/ca-certificates/*
+    flags:
+    - O_RDONLY
+  - path: /etc/group
+    flags:
+    - O_RDONLY
+  - path: /etc/host.conf
+    flags:
+    - O_RDONLY
+  - path: /etc/gai.conf
+    flags:
+    - O_RDONLY
+  - path: /var/log/apt/*
+    flags:
+    - O_RDONLY
+  - path: /var/lib/dpkg
+    flags:
+    - O_RDONLY
+  - path: /var/lib/apt
+    flags:
+    - O_RDONLY
+  - path: /etc/apt
+    flags:
+    - O_RDONLY
+  - path: /etc/dpkg
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl
+    flags:
+    - O_RDONLY
+  - path: /etc/ca-certificates
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.conf.d
+    flags:
+    - O_RDONLY
+  - path: /usr/local/share/ca-certificates
+    flags:
+    - O_RDONLY
+  - path: /var/log/apt
+    flags:
+    - O_RDONLY
   seccompProfile:
     spec:
       defaultAction: ''

--- a/_artifacts/log4j-sbobs/cp-chain-observer.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-observer.yaml
@@ -41,6 +41,105 @@ spec:
   - path: /etc/passwd
     flags:
     - O_RDONLY
+  - path: /var/lib/dpkg/*
+    flags:
+    - O_RDONLY
+  - path: /var/lib/apt/*
+    flags:
+    - O_RDONLY
+  - path: /var/log/apt/*
+    flags:
+    - O_RDONLY
+  - path: /var/log/dpkg.log
+    flags:
+    - O_RDONLY
+  - path: /etc/apt/*
+    flags:
+    - O_RDONLY
+  - path: /etc/dpkg/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ca-certificates/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ca-certificates.conf
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.conf.d/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.conf
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.cache
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.cache~
+    flags:
+    - O_RDONLY
+  - path: /etc/gcrypt/*
+    flags:
+    - O_RDONLY
+  - path: /usr/local/share/ca-certificates/*
+    flags:
+    - O_RDONLY
+  - path: /usr/local/lib/*
+    flags:
+    - O_RDONLY
+  - path: /etc/group
+    flags:
+    - O_RDONLY
+  - path: /etc/host.conf
+    flags:
+    - O_RDONLY
+  - path: /etc/gai.conf
+    flags:
+    - O_RDONLY
+  - path: /etc/debconf.conf
+    flags:
+    - O_RDONLY
+  - path: /etc/machine-id
+    flags:
+    - O_RDONLY
+  - path: /etc/shadow
+    flags:
+    - O_RDONLY
+  - path: /var/lib/dpkg
+    flags:
+    - O_RDONLY
+  - path: /var/lib/apt
+    flags:
+    - O_RDONLY
+  - path: /var/log/apt
+    flags:
+    - O_RDONLY
+  - path: /etc/apt
+    flags:
+    - O_RDONLY
+  - path: /etc/dpkg
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl
+    flags:
+    - O_RDONLY
+  - path: /etc/ca-certificates
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.conf.d
+    flags:
+    - O_RDONLY
+  - path: /etc/gcrypt
+    flags:
+    - O_RDONLY
+  - path: /usr/local/share/ca-certificates
+    flags:
+    - O_RDONLY
+  - path: /usr/local/lib
+    flags:
+    - O_RDONLY
   seccompProfile:
     spec:
       defaultAction: ''

--- a/_artifacts/log4j-sbobs/cp-chain-postgres.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-postgres.yaml
@@ -71,6 +71,33 @@ spec:
     flags:
     - O_RDWR
     - O_CREAT
+  - path: /var/lib/postgresql/*
+    flags:
+    - O_RDONLY
+  - path: /run/postgresql/*
+    flags:
+    - O_RDONLY
+  - path: /etc/ld.so.cache
+    flags:
+    - O_RDONLY
+  - path: /etc/locale.alias
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl/*
+    flags:
+    - O_RDONLY
+  - path: /etc/gai.conf
+    flags:
+    - O_RDONLY
+  - path: /var/lib/postgresql
+    flags:
+    - O_RDONLY
+  - path: /run/postgresql
+    flags:
+    - O_RDONLY
+  - path: /etc/ssl
+    flags:
+    - O_RDONLY
   seccompProfile:
     spec:
       defaultAction: ''


### PR DESCRIPTION
## Problem
The demo containers flood **R0002 (Files Access Anomalies)** at startup, drowning the attack signal:
- `chain-observer` runs apt-get/dpkg → `/var/lib/dpkg/**` (×161), `/var/lib/apt/**`, cert refresh
- `chain-postgres` touches its data dir → `/var/lib/postgresql/data/**` (×1105)
- `chain-backend` JVM loads → `/opt/java/openjdk/**`

## Fix
Allowlist the benign paths with the opens **`WildcardIdentifier '*'`** (`dynamicpathdetector`: zero-or-more path segments, opens-only). Per `compareSegmentsIndex`, a **trailing `*` matches one-or-more segments and NOT the bare parent dir**, so each `/dir/*` is paired with an explicit `/dir` entry. R0002 uses `ap.was_path_opened` (path-only) so flags are irrelevant.

## Verified on a live cluster
Benign **R0002: 200+ → 0**, attack signal untouched: R0001 (unexpected exec ×39), R0005 (DNS exfil), R0011 (egress), R1001 (drift). Legacy ap-chain/nn-chain untouched; all four strict-parse against v1beta1 ContainerProfile.