### PR TITLE
chore(log4j-sbobs): allowlist benign capabilities to silence R0004

### DIFF
--- a/_artifacts/log4j-sbobs/cp-chain-backend.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-backend.yaml
@@ -225,3 +225,20 @@ spec:
         app: chain-postgres
     namespaceSelector: null
     type: internal
+  capabilities:
+  - CAP_AUDIT_WRITE
+  - CAP_CHOWN
+  - CAP_DAC_OVERRIDE
+  - CAP_DAC_READ_SEARCH
+  - CAP_FOWNER
+  - CAP_FSETID
+  - CAP_KILL
+  - CAP_MKNOD
+  - CAP_NET_ADMIN
+  - CAP_NET_BIND_SERVICE
+  - CAP_NET_RAW
+  - CAP_SETFCAP
+  - CAP_SETGID
+  - CAP_SETPCAP
+  - CAP_SETUID
+  - CAP_SYS_CHROOT

--- a/_artifacts/log4j-sbobs/cp-chain-frontend.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-frontend.yaml
@@ -9,11 +9,22 @@ spec:
   imageID: docker.io/library/nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
   imageTag: docker.io/library/nginx:1.27-alpine
   capabilities:
+  - CAP_AUDIT_WRITE
   - CAP_CHOWN
   - CAP_DAC_OVERRIDE
+  - CAP_DAC_READ_SEARCH
+  - CAP_FOWNER
+  - CAP_FSETID
+  - CAP_KILL
+  - CAP_MKNOD
+  - CAP_NET_ADMIN
   - CAP_NET_BIND_SERVICE
+  - CAP_NET_RAW
+  - CAP_SETFCAP
   - CAP_SETGID
+  - CAP_SETPCAP
   - CAP_SETUID
+  - CAP_SYS_CHROOT
   execs:
   - path: /usr/sbin/nginx
     args:

--- a/_artifacts/log4j-sbobs/cp-chain-observer.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-observer.yaml
@@ -177,3 +177,20 @@ spec:
         app: chain-frontend
     namespaceSelector: null
     type: internal
+  capabilities:
+  - CAP_AUDIT_WRITE
+  - CAP_CHOWN
+  - CAP_DAC_OVERRIDE
+  - CAP_DAC_READ_SEARCH
+  - CAP_FOWNER
+  - CAP_FSETID
+  - CAP_KILL
+  - CAP_MKNOD
+  - CAP_NET_ADMIN
+  - CAP_NET_BIND_SERVICE
+  - CAP_NET_RAW
+  - CAP_SETFCAP
+  - CAP_SETGID
+  - CAP_SETPCAP
+  - CAP_SETUID
+  - CAP_SYS_CHROOT

--- a/_artifacts/log4j-sbobs/cp-chain-postgres.yaml
+++ b/_artifacts/log4j-sbobs/cp-chain-postgres.yaml
@@ -9,14 +9,22 @@ spec:
   imageID: docker.io/library/postgres@sha256:54c00787dc4e66a69c51e05cb86eead99a3ff2fc04a98bdce6f5cd1130fdbb56
   imageTag: docker.io/library/postgres:15-bookworm
   capabilities:
+  - CAP_AUDIT_WRITE
   - CAP_CHOWN
   - CAP_DAC_OVERRIDE
   - CAP_DAC_READ_SEARCH
   - CAP_FOWNER
   - CAP_FSETID
   - CAP_KILL
+  - CAP_MKNOD
+  - CAP_NET_ADMIN
+  - CAP_NET_BIND_SERVICE
+  - CAP_NET_RAW
+  - CAP_SETFCAP
   - CAP_SETGID
+  - CAP_SETPCAP
   - CAP_SETUID
+  - CAP_SYS_CHROOT
   execs:
   - path: /usr/lib/postgresql/16/bin/postgres
     args:


### PR DESCRIPTION
Follow-up to #163 (opens). The demo containers are unprivileged root containers (no securityContext, no added caps). **R0004 (Linux Capabilities Anomalies)** fires on the kernel capability *checks* their normal root startup performs — `DAC_OVERRIDE`/`DAC_READ_SEARCH` for file reads (dpkg/debconf/postgres), `FSETID`/`CHOWN`/`FOWNER` for package file perms, `NET_ADMIN`/`NET_RAW` for network setup. They fire during benign startup with **no attack present**; the log4shell signal is R0001 + R0005, never the caps.

Sets `spec.capabilities` on all four cp-chain profiles to the container-runtime default cap set + `DAC_READ_SEARCH`/`NET_ADMIN` (observed from node-agent's cap-check tracer).

**Verified live:** R0004 → **0** across two restart rounds, attack signal untouched (R0001 exec, R0005 DNS exfil, R0011 egress, R1001 drift).