### PR TITLE
Runtime network rules: ingress anomaly + selector matching (pin node-agent celnet)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,7 @@ kubescape:
 	helm repo update
 	helm upgrade --install kubescape kubescape/kubescape-operator --version $(KUBESCAPE_CHART_VER) -n honey --create-namespace --values kubescape/values.yaml $(KS_RUNC_FLAGS) $(KS_LEARN_FLAGS) $(KS_POST_RENDER_FLAGS)
 	kubectl apply -f kubescape/default-rules.yaml
+	kubectl apply -f kubescape/default-rule-binding.yaml
 
 # Wait for node-agent to become Ready by itself. This is a WAIT, never a
 # restart: node-agent binds user-supplied profiles and starts its learning

--- a/example/redis/client.yaml
+++ b/example/redis/client.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: redis-client
-        kubescape.io/ignore: "true"
+        kubescape.io/user-defined-profile: redis-client
     spec:
       containers:
         - name: client

--- a/example/redis/client.yaml
+++ b/example/redis/client.yaml
@@ -1,16 +1,8 @@
-# The ONE allowed redis client — the reference workload the SBoB whitelists.
-#
-# This exists so the redis ContainerProfile has exactly one legitimate
-# ingress peer to point at. In your own cluster you DELETE this file and
-# instead point the SBoB's ingress selector at YOUR real client (see
-# sbobs/cp-redis.yaml and README.md). The label `app: redis-client` and the
-# namespace `redis-demo` are the two things the SBoB matches on — keep them
-# in sync with whatever you substitute.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-client
-  namespace: redis-demo
+  namespace: redis
   labels:
     app: redis-client
 spec:
@@ -26,17 +18,14 @@ spec:
       containers:
         - name: client
           image: redis:7-alpine
-          # Steady, benign RESP traffic to redis:6379 — the "normal" the SBoB
-          # is learned/authored against. Only SET/GET/PING: a well-behaved
-          # client, nothing that would trip a rule on the server side.
           command: ["/bin/sh", "-c"]
           args:
             - |
               i=0
               while true; do
-                redis-cli -h redis -p 6379 SET "k:$i" "v:$i" >/dev/null
-                redis-cli -h redis -p 6379 GET "k:$i" >/dev/null
-                redis-cli -h redis -p 6379 PING >/dev/null
+                redis-cli -h redis-master -p 6379 SET "k:$i" "v:$i" >/dev/null
+                redis-cli -h redis-master -p 6379 GET "k:$i" >/dev/null
+                redis-cli -h redis-master -p 6379 PING >/dev/null
                 i=$((i+1)); sleep 2
               done
           resources:

--- a/example/redis/client.yaml
+++ b/example/redis/client.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: redis-client
+        kubescape.io/ignore: "true"
     spec:
       containers:
         - name: client
@@ -24,8 +25,6 @@ spec:
               i=0
               while true; do
                 redis-cli -h redis-master -p 6379 SET "k:$i" "v:$i" >/dev/null
-                redis-cli -h redis-master -p 6379 GET "k:$i" >/dev/null
-                redis-cli -h redis-master -p 6379 PING >/dev/null
                 i=$((i+1)); sleep 2
               done
           resources:

--- a/example/redis/distros/DEMO.md
+++ b/example/redis/distros/DEMO.md
@@ -63,34 +63,26 @@ print("functional FPs:", len(fp), dict(Counter(x["labels"].get("rule_id") for x 
 print("attack TPs (distinct rules):", len(tp), tp)'
 ```
 
-## 5. Allow a client by identity (ingress)
+## 5. Detect a client, then allowlist it by identity (ingress)
 
 `CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
 
-Deploy the client — unlisted, R0012 fires:
+Watch R0012 on redis-master's node-agent:
+
+```
+MNODE=$(kubectl -n redis get pod redis-master-0 -o jsonpath='{.spec.nodeName}')
+NA=$(kubectl -n honey get pod -o wide --field-selector spec.nodeName=$MNODE --no-headers | awk '/node-agent/{print $1;exit}')
+kubectl -n honey logs -f $NA | grep "Unexpected ingress network"
+```
+
+Deploy the client (`app: redis-client`, unlisted) — R0012 fires:
 
 ```
 kubectl apply -f ../client.yaml
 ```
 
-Allowlist by label — R0012 silent:
+Allowlist that identity — R0012 stops within ~30s (profile-projection refresh):
 
 ```
 kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"redis-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"redis"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
-```
-
-## 6. Selector matrix — allowlisted silent, rogue alerts, same-node and cross-node
-
-```
-./selector-repro.sh
-```
-
-Expect:
-
-```
-client             node         allowlisted R0012  verdict
-sel-allow-intra    <master>     yes         0      PASS
-sel-rogue-intra    <master>     no          >0     PASS
-sel-allow-inter    <other>      yes         0      PASS
-sel-rogue-inter    <other>      no          >0     PASS
 ```

--- a/example/redis/distros/DEMO.md
+++ b/example/redis/distros/DEMO.md
@@ -62,3 +62,40 @@ tp=sorted({x["labels"].get("rule_id") for x in al if x.get("startsAt","")>=t0})
 print("functional FPs:", len(fp), dict(Counter(x["labels"].get("rule_id") for x in fp)) or "CLEAN")
 print("attack TPs (distinct rules):", len(tp), tp)'
 ```
+
+## 5. Allow a client by identity (ingress, label-based)
+
+Requires the `sbob-rc5s-celnet` node-agent (pinned in `kubescape/values.yaml`),
+which adds `cp.was_selector_in_ingress`. Rule **R0012** (Unexpected Ingress
+Network Traffic) fires on an inbound peer that matches **neither** an
+`ipAddress`/CIDR ingress entry **nor** a `podSelector` ingress entry — so you can
+allowlist a client by its **label**, and it holds across pod reschedules / IP
+changes (unlike a learned IP).
+
+`CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
+
+### Phase 1 — an unlisted client alerts
+Start with no ingress allowlist on the redis SBoB, then run a client that talks
+to redis:
+
+```
+kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":null}}'
+kubectl -n redis run demo-client --image=redis:7-alpine --labels=app=redis-client \
+  --command -- /bin/sh -c 'while true; do redis-cli -h redis-master -p 6379 PING; sleep 1; done'
+```
+→ R0012 fires: `Unexpected ingress network communication from: <client-ip>:6379 … to: redis`.
+
+### Phase 2 — allowlist it by label, and it goes quiet
+Add one ingress stanza that names the client by `podSelector` (no IP):
+
+```
+kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":[{
+  "type":"internal",
+  "podSelector":{"matchLabels":{"app":"redis-client"}},
+  "namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"redis"}},
+  "ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
+```
+
+Reconnect (delete/recreate the client — it comes back on a **different IP**, same
+label) and R0012 stays **silent**: `cp.was_selector_in_ingress` resolves the peer
+IP to its pod and matches the label. A client with any *other* label still alerts.

--- a/example/redis/distros/DEMO.md
+++ b/example/redis/distros/DEMO.md
@@ -78,3 +78,19 @@ Allowlist by label — R0012 silent:
 ```
 kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"redis-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"redis"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
 ```
+
+## 6. Selector matrix — allowlisted silent, rogue alerts, same-node and cross-node
+
+```
+./selector-repro.sh
+```
+
+Expect:
+
+```
+client             node         allowlisted R0012  verdict
+sel-allow-intra    <master>     yes         0      PASS
+sel-rogue-intra    <master>     no          >0     PASS
+sel-allow-inter    <other>      yes         0      PASS
+sel-rogue-inter    <other>      no          >0     PASS
+```

--- a/example/redis/distros/DEMO.md
+++ b/example/redis/distros/DEMO.md
@@ -63,39 +63,28 @@ print("functional FPs:", len(fp), dict(Counter(x["labels"].get("rule_id") for x 
 print("attack TPs (distinct rules):", len(tp), tp)'
 ```
 
-## 5. Allow a client by identity (ingress, label-based)
+## 5. Allow a client by identity (ingress)
 
-Requires the `sbob-rc5s-celnet` node-agent (pinned in `kubescape/values.yaml`),
-which adds `cp.was_selector_in_ingress`. Rule **R0012** (Unexpected Ingress
-Network Traffic) fires on an inbound peer that matches **neither** an
-`ipAddress`/CIDR ingress entry **nor** a `podSelector` ingress entry — so you can
-allowlist a client by its **label**, and it holds across pod reschedules / IP
-changes (unlike a learned IP).
+Needs the `sbob-rc5s-celnet` node-agent. `CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
 
-`CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
-
-### Phase 1 — an unlisted client alerts
-Start with no ingress allowlist on the redis SBoB, then run a client that talks
-to redis:
+Unlisted client — R0012 fires:
 
 ```
 kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":null}}'
-kubectl -n redis run demo-client --image=redis:7-alpine --labels=app=redis-client \
-  --command -- /bin/sh -c 'while true; do redis-cli -h redis-master -p 6379 PING; sleep 1; done'
-```
-→ R0012 fires: `Unexpected ingress network communication from: <client-ip>:6379 … to: redis`.
-
-### Phase 2 — allowlist it by label, and it goes quiet
-Add one ingress stanza that names the client by `podSelector` (no IP):
-
-```
-kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":[{
-  "type":"internal",
-  "podSelector":{"matchLabels":{"app":"redis-client"}},
-  "namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"redis"}},
-  "ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
+kubectl -n redis run redis-client --image=redis:7-alpine --labels=app=redis-client --restart=Never --command -- /bin/sh -c 'while true; do redis-cli -h redis-master PING; sleep 1; done'
 ```
 
-Reconnect (delete/recreate the client — it comes back on a **different IP**, same
-label) and R0012 stays **silent**: `cp.was_selector_in_ingress` resolves the peer
-IP to its pod and matches the label. A client with any *other* label still alerts.
+Allowlist by label — R0012 silent:
+
+```
+kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"redis-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"redis"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
+kubectl -n redis delete pod redis-client
+kubectl -n redis run redis-client --image=redis:7-alpine --labels=app=redis-client --restart=Never --command -- /bin/sh -c 'while true; do redis-cli -h redis-master PING; sleep 1; done'
+```
+
+Check (R0012 for ns redis):
+
+```
+kubectl -n honey port-forward svc/alertmanager 9093:9093 &
+curl -s localhost:9093/api/v2/alerts | python3 -c 'import json,sys;print([x["annotations"]["message"] for x in json.load(sys.stdin) if x["labels"].get("rule_id")=="R0012" and x["labels"].get("namespace")=="redis"])'
+```

--- a/example/redis/distros/DEMO.md
+++ b/example/redis/distros/DEMO.md
@@ -65,26 +65,16 @@ print("attack TPs (distinct rules):", len(tp), tp)'
 
 ## 5. Allow a client by identity (ingress)
 
-Needs the `sbob-rc5s-celnet` node-agent. `CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
+`CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
 
-Unlisted client — R0012 fires:
+Deploy the client — unlisted, R0012 fires:
 
 ```
-kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":null}}'
-kubectl -n redis run redis-client --image=redis:7-alpine --labels=app=redis-client --restart=Never --command -- /bin/sh -c 'while true; do redis-cli -h redis-master PING; sleep 1; done'
+kubectl apply -f ../client.yaml
 ```
 
 Allowlist by label — R0012 silent:
 
 ```
 kubectl -n redis patch $CP redis --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"redis-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"redis"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
-kubectl -n redis delete pod redis-client
-kubectl -n redis run redis-client --image=redis:7-alpine --labels=app=redis-client --restart=Never --command -- /bin/sh -c 'while true; do redis-cli -h redis-master PING; sleep 1; done'
-```
-
-Check (R0012 for ns redis):
-
-```
-kubectl -n honey port-forward svc/alertmanager 9093:9093 &
-curl -s localhost:9093/api/v2/alerts | python3 -c 'import json,sys;print([x["annotations"]["message"] for x in json.load(sys.stdin) if x["labels"].get("rule_id")=="R0012" and x["labels"].get("namespace")=="redis"])'
 ```

--- a/example/redis/distros/DEMO.md
+++ b/example/redis/distros/DEMO.md
@@ -75,9 +75,11 @@ NA=$(kubectl -n honey get pod -o wide --field-selector spec.nodeName=$MNODE --no
 kubectl -n honey logs -f $NA | grep "Unexpected ingress network"
 ```
 
-Deploy the client (`app: redis-client`, unlisted) — R0012 fires:
+Deploy the client with its own SBoB (so the client's own redis-cli/egress stay
+in-profile and don't self-alert). Unlisted on redis-master — R0012 fires:
 
 ```
+kubectl apply -f sbobs/cp-redis-client.yaml
 kubectl apply -f ../client.yaml
 ```
 

--- a/example/redis/distros/demo-all.md
+++ b/example/redis/distros/demo-all.md
@@ -1,0 +1,79 @@
+# Redis-protocol distros — detect + allowlist a client by identity (ingress)
+
+Same flow as `DEMO.md` §5, for the other distros. Bring up the stack first:
+
+```
+make kubescape
+make alertmanager
+```
+
+`CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
+
+Each section: deploy + bind the SBoB, deploy an unlisted client (R0012 fires),
+then allowlist it by identity (R0012 stops within ~30s).
+
+| distro    | ns         | server pod       | service         | client manifest        |
+|-----------|------------|------------------|-----------------|------------------------|
+| valkey    | valkey     | valkey-primary-0 | valkey-primary  | valkey-client.yaml     |
+| keydb     | keydb      | keydb-0          | keydb           | keydb-client.yaml      |
+| dragonfly | dragonfly  | dragonfly-0      | dragonfly       | dragonfly-client.yaml  |
+
+## valkey
+
+```
+./deploy-distros.sh valkey sbob
+```
+Watch R0012 on valkey-primary's node-agent:
+```
+MNODE=$(kubectl -n valkey get pod valkey-primary-0 -o jsonpath='{.spec.nodeName}')
+NA=$(kubectl -n honey get pod -o wide --field-selector spec.nodeName=$MNODE --no-headers | awk '/node-agent/{print $1;exit}')
+kubectl -n honey logs -f $NA | grep "Unexpected ingress network"
+```
+Deploy the client (unlisted) — R0012 fires:
+```
+kubectl apply -f valkey-client.yaml
+```
+Allowlist that identity — R0012 stops:
+```
+kubectl -n valkey patch $CP valkey --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"valkey-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"valkey"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
+```
+
+## keydb
+
+```
+./deploy-distros.sh keydb sbob
+```
+Watch R0012 on keydb's node-agent:
+```
+MNODE=$(kubectl -n keydb get pod keydb-0 -o jsonpath='{.spec.nodeName}')
+NA=$(kubectl -n honey get pod -o wide --field-selector spec.nodeName=$MNODE --no-headers | awk '/node-agent/{print $1;exit}')
+kubectl -n honey logs -f $NA | grep "Unexpected ingress network"
+```
+Deploy the client (unlisted) — R0012 fires:
+```
+kubectl apply -f keydb-client.yaml
+```
+Allowlist that identity — R0012 stops:
+```
+kubectl -n keydb patch $CP keydb --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"keydb-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"keydb"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
+```
+
+## dragonfly
+
+```
+./deploy-distros.sh dragonfly sbob
+```
+Watch R0012 on dragonfly's node-agent:
+```
+MNODE=$(kubectl -n dragonfly get pod dragonfly-0 -o jsonpath='{.spec.nodeName}')
+NA=$(kubectl -n honey get pod -o wide --field-selector spec.nodeName=$MNODE --no-headers | awk '/node-agent/{print $1;exit}')
+kubectl -n honey logs -f $NA | grep "Unexpected ingress network"
+```
+Deploy the client (unlisted) — R0012 fires:
+```
+kubectl apply -f dragonfly-client.yaml
+```
+Allowlist that identity — R0012 stops:
+```
+kubectl -n dragonfly patch $CP dragonfly --type merge -p '{"spec":{"ingress":[{"type":"internal","podSelector":{"matchLabels":{"app":"dragonfly-client"}},"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"dragonfly"}},"ports":[{"name":"TCP-6379","port":6379,"protocol":"TCP"}]}]}}'
+```

--- a/example/redis/distros/dragonfly-client.yaml
+++ b/example/redis/distros/dragonfly-client.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dragonfly-client
+  namespace: dragonfly
+  labels:
+    app: dragonfly-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dragonfly-client
+  template:
+    metadata:
+      labels:
+        app: dragonfly-client
+        kubescape.io/ignore: "true"
+    spec:
+      containers:
+        - name: client
+          image: redis:7-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              i=0
+              while true; do
+                redis-cli -h dragonfly -p 6379 SET "k:$i" "v:$i" >/dev/null
+                i=$((i+1)); sleep 2
+              done
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }

--- a/example/redis/distros/keydb-client.yaml
+++ b/example/redis/distros/keydb-client.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keydb-client
+  namespace: keydb
+  labels:
+    app: keydb-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keydb-client
+  template:
+    metadata:
+      labels:
+        app: keydb-client
+        kubescape.io/ignore: "true"
+    spec:
+      containers:
+        - name: client
+          image: redis:7-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              i=0
+              while true; do
+                redis-cli -h keydb -p 6379 SET "k:$i" "v:$i" >/dev/null
+                i=$((i+1)); sleep 2
+              done
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }

--- a/example/redis/distros/sbobs/cp-dragonfly.yaml
+++ b/example/redis/distros/sbobs/cp-dragonfly.yaml
@@ -61,10 +61,7 @@ spec:
     - --admin_nopass
     path: /usr/bin/setpriv
   - args:
-    - /usr/bin/nc
-    - -q1
-    - localhost
-    - '9999'
+    - ⋯⋯
     path: /usr/bin/nc.openbsd
   - args:
     - /usr/bin/tini
@@ -77,16 +74,7 @@ spec:
     - --admin_nopass
     path: /usr/bin/tini
   - args:
-    - /usr/local/bin/entrypoint.sh
-    - dragonfly
-    - --logtostderr
-    - --alsologtostderr
-    - --break_replication_on_master_restart=true
-    - --primary_port_http_enabled=false
-    - --admin_port=9999
-    - --admin_nopass
-    - /bin/sh
-    - /usr/local/bin/healthcheck.sh
+    - ⋯⋯
     path: /usr/bin/dash
   - args:
     - /usr/bin/id

--- a/example/redis/distros/sbobs/cp-keydb.yaml
+++ b/example/redis/distros/sbobs/cp-keydb.yaml
@@ -17,35 +17,13 @@ spec:
   egress:
   - dns: ''
     dnsNames: null
-    identifier: e656ed0238ada70c2ec985b2a57b11dbb945d58c1c4e799cbfceaeefe67ebc26
-    namespaceSelector: null
-    podSelector:
+    namespaceSelector: &id001
       matchLabels:
-        app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '1'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-1
-    ports:
-    - name: TCP-6379
-      port: 6379
-      protocol: TCP
-    type: internal
-  - dns: ''
-    dnsNames: null
-    identifier: acf3acacc39ccc3af4417be8024ad8537d2ca7987f2677ef3a655b4280359f7e
-    namespaceSelector: null
-    podSelector:
+        kubernetes.io/metadata.name: keydb
+    podSelector: &id002
       matchLabels:
-        app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '2'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-2
+        app.kubernetes.io/instance: keydb
     ports:
     - name: TCP-6379
       port: 6379
@@ -127,35 +105,8 @@ spec:
   ingress:
   - dns: ''
     dnsNames: null
-    identifier: acf3acacc39ccc3af4417be8024ad8537d2ca7987f2677ef3a655b4280359f7e
-    namespaceSelector: null
-    podSelector:
-      matchLabels:
-        app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '2'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-2
-    ports:
-    - name: TCP-6379
-      port: 6379
-      protocol: TCP
-    type: internal
-  - dns: ''
-    dnsNames: null
-    identifier: e656ed0238ada70c2ec985b2a57b11dbb945d58c1c4e799cbfceaeefe67ebc26
-    namespaceSelector: null
-    podSelector:
-      matchLabels:
-        app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '1'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-1
+    namespaceSelector: *id001
+    podSelector: *id002
     ports:
     - name: TCP-6379
       port: 6379

--- a/example/redis/distros/sbobs/cp-keydb.yaml
+++ b/example/redis/distros/sbobs/cp-keydb.yaml
@@ -17,35 +17,13 @@ spec:
   egress:
   - dns: ''
     dnsNames: null
-    identifier: e656ed0238ada70c2ec985b2a57b11dbb945d58c1c4e799cbfceaeefe67ebc26
-    namespaceSelector: null
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: keydb
     podSelector:
       matchLabels:
-        app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '1'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-1
-    ports:
-    - name: TCP-6379
-      port: 6379
-      protocol: TCP
-    type: internal
-  - dns: ''
-    dnsNames: null
-    identifier: acf3acacc39ccc3af4417be8024ad8537d2ca7987f2677ef3a655b4280359f7e
-    namespaceSelector: null
-    podSelector:
-      matchLabels:
         app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '2'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-2
     ports:
     - name: TCP-6379
       port: 6379
@@ -127,35 +105,13 @@ spec:
   ingress:
   - dns: ''
     dnsNames: null
-    identifier: acf3acacc39ccc3af4417be8024ad8537d2ca7987f2677ef3a655b4280359f7e
-    namespaceSelector: null
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: keydb
     podSelector:
       matchLabels:
-        app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '2'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-2
-    ports:
-    - name: TCP-6379
-      port: 6379
-      protocol: TCP
-    type: internal
-  - dns: ''
-    dnsNames: null
-    identifier: e656ed0238ada70c2ec985b2a57b11dbb945d58c1c4e799cbfceaeefe67ebc26
-    namespaceSelector: null
-    podSelector:
-      matchLabels:
         app.kubernetes.io/instance: keydb
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: keydb
-        app.kubernetes.io/version: 6.3.2
-        apps.kubernetes.io/pod-index: '1'
-        helm.sh/chart: keydb-0.48.0
-        statefulset.kubernetes.io/pod-name: keydb-1
     ports:
     - name: TCP-6379
       port: 6379

--- a/example/redis/distros/sbobs/cp-keydb.yaml
+++ b/example/redis/distros/sbobs/cp-keydb.yaml
@@ -109,42 +109,16 @@ spec:
     - --replicaof keydb-2.keydb-headless 6379
     path: /usr/local/bin/keydb-server
   - args:
-    - /health/ping_readiness_local.sh
-    - '1'
-    - /health/ping_liveness_local.sh
-    - '5'
-    - /utils/server.sh
+    - ⋯⋯
     path: /bin/bash
   - args:
-    - /usr/bin/timeout
-    - -s
-    - '15'
-    - '1'
-    - keydb-cli
-    - -h
-    - localhost
-    - -p
-    - '6379'
-    - GET
-    - 90f717dd-0e68-43b8-9363-fddaad00d6c9
-    - '5'
-    - PING
+    - ⋯⋯
     path: /usr/bin/timeout
   - args:
-    - /usr/local/bin/keydb-cli
-    - -h
-    - localhost
-    - -p
-    - '6379'
-    - GET
-    - 90f717dd-0e68-43b8-9363-fddaad00d6c9
-    - PING
+    - ⋯⋯
     path: /usr/local/bin/keydb-cli
   - args:
-    - /bin/sh
-    - -c
-    - /health/ping_readiness_local.sh 1
-    - /health/ping_liveness_local.sh 5
+    - ⋯⋯
     path: /bin/dash
   - args:
     - /bin/hostname

--- a/example/redis/distros/sbobs/cp-keydb.yaml
+++ b/example/redis/distros/sbobs/cp-keydb.yaml
@@ -17,13 +17,35 @@ spec:
   egress:
   - dns: ''
     dnsNames: null
-    namespaceSelector: &id001
+    identifier: e656ed0238ada70c2ec985b2a57b11dbb945d58c1c4e799cbfceaeefe67ebc26
+    namespaceSelector: null
+    podSelector:
       matchLabels:
-        kubernetes.io/metadata.name: keydb
-    podSelector: &id002
-      matchLabels:
-        app.kubernetes.io/name: keydb
         app.kubernetes.io/instance: keydb
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keydb
+        app.kubernetes.io/version: 6.3.2
+        apps.kubernetes.io/pod-index: '1'
+        helm.sh/chart: keydb-0.48.0
+        statefulset.kubernetes.io/pod-name: keydb-1
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
+  - dns: ''
+    dnsNames: null
+    identifier: acf3acacc39ccc3af4417be8024ad8537d2ca7987f2677ef3a655b4280359f7e
+    namespaceSelector: null
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/instance: keydb
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keydb
+        app.kubernetes.io/version: 6.3.2
+        apps.kubernetes.io/pod-index: '2'
+        helm.sh/chart: keydb-0.48.0
+        statefulset.kubernetes.io/pod-name: keydb-2
     ports:
     - name: TCP-6379
       port: 6379
@@ -105,8 +127,35 @@ spec:
   ingress:
   - dns: ''
     dnsNames: null
-    namespaceSelector: *id001
-    podSelector: *id002
+    identifier: acf3acacc39ccc3af4417be8024ad8537d2ca7987f2677ef3a655b4280359f7e
+    namespaceSelector: null
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/instance: keydb
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keydb
+        app.kubernetes.io/version: 6.3.2
+        apps.kubernetes.io/pod-index: '2'
+        helm.sh/chart: keydb-0.48.0
+        statefulset.kubernetes.io/pod-name: keydb-2
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
+  - dns: ''
+    dnsNames: null
+    identifier: e656ed0238ada70c2ec985b2a57b11dbb945d58c1c4e799cbfceaeefe67ebc26
+    namespaceSelector: null
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/instance: keydb
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keydb
+        app.kubernetes.io/version: 6.3.2
+        apps.kubernetes.io/pod-index: '1'
+        helm.sh/chart: keydb-0.48.0
+        statefulset.kubernetes.io/pod-name: keydb-1
     ports:
     - name: TCP-6379
       port: 6379

--- a/example/redis/distros/sbobs/cp-redis-client.yaml
+++ b/example/redis/distros/sbobs/cp-redis-client.yaml
@@ -1,0 +1,176 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ContainerProfile
+metadata:
+  name: redis-client
+  namespace: redis
+  annotations:
+    kubescape.io/managed-by: User
+spec:
+  architectures:
+  - amd64
+  capabilities: []
+  execs:
+  - path: /usr/local/bin/redis-cli
+    args:
+    - /usr/local/bin/redis-cli
+    - -h
+    - redis-master
+    - -p
+    - '6379'
+    - SET
+    - ⋯⋯
+  - path: /bin/busybox
+    args:
+    - /bin/sleep
+    - '2'
+  - path: /bin/busybox
+    args:
+    - /bin/sh
+    - -c
+    - "i=0\nwhile true; do\n  redis-cli -h redis-master -p 6379 SET \"k:$i\" \"v:$i\" >/dev/null\n  i=$((i+1)); sleep 2\ndone\n"
+  opens:
+  - flags:
+    - O_LARGEFILE
+    - O_WRONLY
+    - O_CREAT
+    - O_TRUNC
+    path: /dev/null
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /etc/hosts
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /etc/ld-musl-x86_64.path
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /etc/resolv.conf
+  - flags:
+    - O_LARGEFILE
+    - O_CLOEXEC
+    - O_RDONLY
+    path: /lib/libcrypto.so.3
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /lib/libssl.so.3
+  - flags:
+    - O_DIRECTORY
+    - O_CLOEXEC
+    - O_RDONLY
+    path: /proc/⋯/task/1/fd
+  - flags:
+    - O_RDONLY
+    - O_CLOEXEC
+    path: /proc/⋯/vm/overcommit_memory
+  - flags:
+    - O_RDONLY
+    path: /sys/kernel/mm/transparent_hugepage/enabled
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /usr/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_RDONLY
+    - O_LARGEFILE
+    path: /usr/lib/libssl.so.3
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /usr/local/lib/libcrypto.so.3
+  - flags:
+    - O_RDONLY
+    - O_LARGEFILE
+    - O_CLOEXEC
+    path: /usr/local/lib/libssl.so.3
+  egress:
+  - dns: ''
+    dnsNames: null
+    identifier: e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3
+    ipAddress: ''
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    podSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    ports:
+    - name: UDP-53
+      port: 53
+      protocol: UDP
+    type: internal
+  - dns: ''
+    dnsNames: null
+    identifier: bdae5e0af800f7b8d49b38f0d64180cd548a5812480a538c24f2379fc6ded2bd
+    ipAddress: ''
+    namespaceSelector: null
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/component: master
+        app.kubernetes.io/instance: redis
+        app.kubernetes.io/name: redis
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
+  ingress: null
+  matchLabels:
+    app: redis-client
+  syscalls:
+  - arch_prctl
+  - bind
+  - brk
+  - capget
+  - capset
+  - chdir
+  - connect
+  - dup2
+  - epoll_pwait
+  - execve
+  - exit
+  - exit_group
+  - faccessat2
+  - fcntl
+  - fork
+  - fstatfs
+  - getpid
+  - gettid
+  - getuid
+  - ioctl
+  - madvise
+  - mprotect
+  - munmap
+  - nanosleep
+  - newfstatat
+  - openat2
+  - prctl
+  - readlink
+  - recvfrom
+  - recvmsg
+  - rt_sigprocmask
+  - rt_sigreturn
+  - sched_getaffinity
+  - sendto
+  - set_tid_address
+  - setgid
+  - setgroups
+  - setsockopt
+  - sigaltstack
+  - socket
+  - statx
+  - tgkill
+  - tkill
+  - unknown
+  - wait4
+  - writev
+  identifiedCallStacks: null

--- a/example/redis/distros/sbobs/cp-redis.yaml
+++ b/example/redis/distros/sbobs/cp-redis.yaml
@@ -124,7 +124,7 @@ spec:
   - flags:
     - O_CLOEXEC
     - O_RDONLY
-    path: /usr/lib/glibc-hwcaps/x86-64-v2/libncursesw.so.6
+    path: /usr/lib/glibc-hwcaps/⋯/libncursesw.so.6
   - flags:
     - O_RDONLY
     - O_CLOEXEC
@@ -150,7 +150,7 @@ spec:
   - flags:
     - O_RDONLY
     - O_CLOEXEC
-    path: /opt/bitnami/redis/lib/glibc-hwcaps/x86-64-v2/libm.so.6
+    path: /opt/bitnami/redis/lib/glibc-hwcaps/⋯/libm.so.6
   - flags:
     - O_RDONLY
     - O_CLOEXEC
@@ -264,7 +264,7 @@ spec:
   - flags:
     - O_RDONLY
     - O_CLOEXEC
-    path: /usr/lib/glibc-hwcaps/x86-64-v3/libncursesw.so.6
+    path: /usr/lib/glibc-hwcaps/⋯/libncursesw.so.6
   - flags:
     - O_CLOEXEC
     - O_RDONLY
@@ -298,7 +298,7 @@ spec:
   - flags:
     - O_RDONLY
     - O_CLOEXEC
-    path: /opt/bitnami/redis/lib/glibc-hwcaps/x86-64-v3/libm.so.6
+    path: /opt/bitnami/redis/lib/glibc-hwcaps/⋯/libm.so.6
   - flags:
     - O_RDONLY
     - O_CLOEXEC

--- a/example/redis/distros/sbobs/cp-redis.yaml
+++ b/example/redis/distros/sbobs/cp-redis.yaml
@@ -79,7 +79,21 @@ spec:
     - '{print $1;}'
     path: /usr/bin/gawk
   identifiedCallStacks: null
-  ingress: null
+  ingress:
+  - dns: ''
+    dnsNames: null
+    identifier: 7b1e9c4a2f6d8e0b3c5a1f9d4e7b2c6a8f0d3e5b1c9a4f7d2e6b0c8a3f5d1e9b
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: redis
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: redis-client
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
   matchLabels:
     app.kubernetes.io/component: master
     app.kubernetes.io/instance: redis

--- a/example/redis/distros/sbobs/cp-redis.yaml
+++ b/example/redis/distros/sbobs/cp-redis.yaml
@@ -79,25 +79,6 @@ spec:
     - '{print $1;}'
     path: /usr/bin/gawk
   identifiedCallStacks: null
-  ingress:
-  - dns: ''
-    dnsNames: null
-    identifier: 7b1e9c4a2f6d8e0b3c5a1f9d4e7b2c6a8f0d3e5b1c9a4f7d2e6b0c8a3f5d1e9b
-    namespaceSelector:
-      matchLabels:
-        kubernetes.io/metadata.name: redis
-    podSelector:
-      matchLabels:
-        app.kubernetes.io/name: redis-client
-    ports:
-    - name: TCP-6379
-      port: 6379
-      protocol: TCP
-    type: internal
-  matchLabels:
-    app.kubernetes.io/component: master
-    app.kubernetes.io/instance: redis
-    app.kubernetes.io/name: redis
   opens:
   - flags:
     - O_RDONLY

--- a/example/redis/distros/sbobs/cp-redis.yaml
+++ b/example/redis/distros/sbobs/cp-redis.yaml
@@ -21,15 +21,7 @@ spec:
   endpoints: null
   execs:
   - args:
-    - /bin/bash
-    - -ec
-    - /health/ping_readiness_local.sh 1
-    - /health/ping_readiness_local.sh
-    - '1'
-    - /health/ping_liveness_local.sh 5
-    - /health/ping_liveness_local.sh
-    - '5'
-    - /opt/bitnami/scripts/start-scripts/start-master.sh
+    - ⋯⋯
     path: /usr/bin/bash
   - args:
     - /usr/bin/timeout

--- a/example/redis/distros/sbobs/cp-redis.yaml
+++ b/example/redis/distros/sbobs/cp-redis.yaml
@@ -33,23 +33,13 @@ spec:
     path: /usr/bin/bash
   - args:
     - /usr/bin/timeout
-    - -s
-    - '15'
-    - '5'
-    - redis-cli
-    - -h
-    - localhost
-    - -p
-    - '6379'
+    - ⋯⋯
     - ping
-    - '1'
+    - ⋯⋯
     path: /usr/bin/timeout
   - args:
     - /opt/bitnami/redis/bin/redis-cli
-    - -h
-    - localhost
-    - -p
-    - '6379'
+    - ⋯⋯
     - ping
     path: /opt/bitnami/redis/bin/redis-cli
   - args:

--- a/example/redis/distros/sbobs/cp-valkey.yaml
+++ b/example/redis/distros/sbobs/cp-valkey.yaml
@@ -39,37 +39,13 @@ spec:
     - /opt/bitnami/valkey/etc/primary.conf
     path: /opt/bitnami/valkey/bin/valkey-server
   - args:
-    - /opt/bitnami/valkey/bin/valkey-cli
-    - -h
-    - localhost
-    - -p
-    - '6379'
-    - ping
+    - ⋯⋯
     path: /opt/bitnami/valkey/bin/valkey-cli
   - args:
-    - /bin/bash
-    - -c
-    - /opt/bitnami/scripts/start-scripts/start-primary.sh
-    - /usr/bin/sh
-    - /health/ping_readiness_local.sh 1
-    - /health/ping_liveness_local.sh 5
-    - /health/ping_liveness_local.sh
-    - '5'
-    - /health/ping_readiness_local.sh
-    - '1'
+    - ⋯⋯
     path: /usr/bin/bash
   - args:
-    - /usr/bin/timeout
-    - -s
-    - '15'
-    - '1'
-    - valkey-cli
-    - -p
-    - '6379'
-    - ping
-    - '5'
-    - -h
-    - localhost
+    - ⋯⋯
     path: /usr/bin/timeout
   - args:
     - /usr/bin/head

--- a/example/redis/distros/selector-repro.sh
+++ b/example/redis/distros/selector-repro.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS=${NS:-redis}
+NA_NS=${NA_NS:-honey}
+WARMUP=${WARMUP:-30}
+DURATION=${DURATION:-60}
+
+kubectl -n "$NS" get pod redis-master-0 >/dev/null
+
+master_node=$(kubectl -n "$NS" get pod redis-master-0 -o jsonpath='{.spec.nodeName}')
+other_node=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -vx "$master_node" | head -1)
+[ -n "$other_node" ] || { echo "need a second node for the inter-node case" >&2; exit 1; }
+
+emit() {
+  local name=$1 kp=$2 node=$3 key=$4 val=$5
+  cat <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $name
+  namespace: $NS
+  labels: { repro: $name }
+spec:
+  replicas: 1
+  selector: { matchLabels: { repro: $name } }
+  template:
+    metadata:
+      labels: { repro: $name, $key: $val }
+    spec:
+      nodeName: $node
+      containers:
+        - name: client
+          image: redis:7-alpine
+          command: ["/bin/sh","-c"]
+          args: ["i=0; while true; do redis-cli -h redis-master -p 6379 SET \"$kp:\$i\" v >/dev/null; i=\$((i+1)); sleep 2; done"]
+YAML
+}
+
+for d in sel-allow-intra sel-rogue-intra sel-allow-inter sel-rogue-inter; do
+  kubectl -n "$NS" delete deploy "$d" --ignore-not-found >/dev/null
+done
+
+{
+  emit sel-allow-intra ai "$master_node" app.kubernetes.io/name redis-client; echo ---
+  emit sel-rogue-intra ri "$master_node" app rogue;                          echo ---
+  emit sel-allow-inter ao "$other_node"  app.kubernetes.io/name redis-client; echo ---
+  emit sel-rogue-inter ro "$other_node"  app rogue
+} | kubectl apply -f -
+
+kubectl -n "$NS" rollout status deploy/sel-allow-intra --timeout=90s
+kubectl -n "$NS" rollout status deploy/sel-rogue-inter --timeout=90s
+sleep "$WARMUP"
+sleep "$DURATION"
+
+na=$(kubectl -n "$NA_NS" get pods -o wide --field-selector spec.nodeName="$master_node" --no-headers | awk '/node-agent/{print $1; exit}')
+logs=$(kubectl -n "$NA_NS" logs "$na" --since="${DURATION}s")
+
+ipof() { kubectl -n "$NS" get pod -l "repro=$1" -o jsonpath='{.items[0].status.podIP}'; }
+count() { printf '%s\n' "$logs" | grep -c "ingress network communication from: $1" || true; }
+
+printf '\n%-18s %-12s %-11s %-6s %-8s\n' client node allowlisted R0012 verdict
+for row in "sel-allow-intra|app.kubernetes.io/name=redis-client|$master_node|yes|0" \
+           "sel-rogue-intra|app=rogue|$master_node|no|>0" \
+           "sel-allow-inter|app.kubernetes.io/name=redis-client|$other_node|yes|0" \
+           "sel-rogue-inter|app=rogue|$other_node|no|>0"; do
+  IFS='|' read -r name sel node allow want <<<"$row"
+  ip=$(ipof "$name"); n=$(count "$ip")
+  if { [ "$want" = 0 ] && [ "$n" -eq 0 ]; } || { [ "$want" = ">0" ] && [ "$n" -gt 0 ]; }; then verdict=PASS; else verdict=FAIL; fi
+  printf '%-18s %-12s %-11s %-6s %-8s\n' "$name" "$node" "$allow" "$n" "$verdict"
+done

--- a/example/redis/distros/valkey-client.yaml
+++ b/example/redis/distros/valkey-client.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-client
+  namespace: valkey
+  labels:
+    app: valkey-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey-client
+  template:
+    metadata:
+      labels:
+        app: valkey-client
+        kubescape.io/ignore: "true"
+    spec:
+      containers:
+        - name: client
+          image: redis:7-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              i=0
+              while true; do
+                redis-cli -h valkey-primary -p 6379 SET "k:$i" "v:$i" >/dev/null
+                i=$((i+1)); sleep 2
+              done
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { cpu: 250m, memory: 128Mi }

--- a/kubescape/default-rule-binding.yaml
+++ b/kubescape/default-rule-binding.yaml
@@ -39,6 +39,7 @@ spec:
     - ruleName: "Exec to pod"
     - ruleName: "Port forward"
     - ruleName: "Unexpected Egress Network Traffic"
+    - ruleName: "Unexpected Ingress Network Traffic"
     - ruleName: "Malicious Ptrace Usage"
     - ruleName: "Unexpected io_uring Operation Detected"
     - ruleName: "Kubelet TLS Exec Request Detected"

--- a/kubescape/default-rules.yaml
+++ b/kubescape/default-rules.yaml
@@ -311,6 +311,7 @@ spec:
               event.pktType == 'OUTGOING'
               && !event.dstAddr.startsWith('127.')
               && !cp.was_address_in_egress(event.containerId, event.dstAddr)
+              && !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0011
       isTriggerAlert: true

--- a/kubescape/default-rules.yaml
+++ b/kubescape/default-rules.yaml
@@ -340,7 +340,7 @@ spec:
               event.pktType == 'HOST'
               && !event.dstAddr.startsWith('127.')
               && !cp.was_address_in_ingress(event.containerId, event.dstAddr)
-              && !cp.was_selector_in_ingress(event.containerId, event.dstAddr)
+              && !cp.was_selector_in_ingress(event.containerId, event.dstNamespace, event.dstPodLabels)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0012
       isTriggerAlert: true

--- a/kubescape/default-rules.yaml
+++ b/kubescape/default-rules.yaml
@@ -308,7 +308,8 @@ spec:
         ruleExpression:
           - eventType: network
             expression: >-
-              event.pktType == 'OUTGOING' && !net.is_private_ip(event.dstAddr)
+              event.pktType == 'OUTGOING'
+              && !event.dstAddr.startsWith('127.')
               && !cp.was_address_in_egress(event.containerId, event.dstAddr)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0011
@@ -316,6 +317,36 @@ spec:
       mitreTactic: TA0010
       mitreTechnique: T1041
       name: Unexpected Egress Network Traffic
+      profileDependency: 0
+      severity: 5
+      supportPolicy: false
+      tags:
+        - whitelisted
+        - network
+        - anomaly
+        - networkprofile
+    - description: >-
+        Detecting unexpected ingress network traffic — an inbound connection whose
+        peer is not whitelisted by the application profile ingress.
+      enabled: true
+      expressions:
+        message: >-
+          'Unexpected ingress network communication from: ' + event.dstAddr + ':' +
+          string(event.dstPort) + ' using ' + event.proto + ' to: ' +
+          event.containerName
+        ruleExpression:
+          - eventType: network
+            expression: >-
+              event.pktType == 'HOST'
+              && !event.dstAddr.startsWith('127.')
+              && !cp.was_address_in_ingress(event.containerId, event.dstAddr)
+              && !cp.was_selector_in_ingress(event.containerId, event.dstAddr)
+        uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
+      id: R0012
+      isTriggerAlert: true
+      mitreTactic: TA0011
+      mitreTechnique: T1071
+      name: Unexpected Ingress Network Traffic
       profileDependency: 0
       severity: 5
       supportPolicy: false

--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -5,7 +5,7 @@ storage:
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5s-celnet
+    tag: sbob-rc5s-celnet@sha256:dc4e66680df35dfb4d747544358b7fca906434a78f40ad3b573855935788b6f2
     pullPolicy: Always
   config:
     alertManagerExporterUrls:

--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -38,5 +38,3 @@ alertCRD:
 clusterName: bobexample
 ksNamespace: honey
 excludeNamespaces: "kubescape,kube-system,kube-public,kube-node-lease,local-path-storage,gmp-system,gmp-public,storm,lightening,cert-manager,kube-flannel,ingress-nginx,olm,px-operator,honey,pl,clickhouse,chain-loadgen"
-excludeLabels:
-  kubescape.io/ignore: ["true"]

--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -6,6 +6,7 @@ nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
     tag: sbob-rc5s-celnet
+    pullPolicy: Always
   config:
     alertManagerExporterUrls:
       - alertmanager.honey.svc.cluster.local:9093

--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -20,11 +20,6 @@ nodeAgent:
       ruleCooldownMaxSize: 20000
 capabilities:
   runtimeDetection: enable
-  # The SBoB demo is runtime-detection only. Disable every scanning capability
-  # the chart enables by default so those components are never installed — this
-  # is both a big install-time speedup (no kubescape config-scanner, no kubevuln,
-  # no host node-scanner, no SBOM generation, no schedulers) and removes work the
-  # demo does not use. Only storage + node-agent + the alert wiring remain.
   configurationScan: disable
   nodeScan: disable
   nodeSbomGeneration: disable

--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -38,3 +38,5 @@ alertCRD:
 clusterName: bobexample
 ksNamespace: honey
 excludeNamespaces: "kubescape,kube-system,kube-public,kube-node-lease,local-path-storage,gmp-system,gmp-public,storm,lightening,cert-manager,kube-flannel,ingress-nginx,olm,px-operator,honey,pl,clickhouse,chain-loadgen"
+excludeLabels:
+  kubescape.io/ignore: ["true"]

--- a/kubescape/values.yaml
+++ b/kubescape/values.yaml
@@ -5,7 +5,7 @@ storage:
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5s-osp
+    tag: sbob-rc5s-celnet
   config:
     alertManagerExporterUrls:
       - alertmanager.honey.svc.cluster.local:9093


### PR DESCRIPTION
## Runtime network rules: ingress anomaly + label-based (selector) matching

Pins `nodeAgent` to **`sbob-rc5s-celnet`**, which adds two CEL helpers —
`cp.was_selector_in_ingress` / `cp.was_selector_in_egress` — that resolve a runtime
peer IP to its pod and match it against a profile's ingress/egress
`podSelector`+`namespaceSelector`. This matches peers by **identity**, so it
survives pod-IP churn (learned IPs go stale on reschedule; selectors don't).
*(node-agent side: branch `feat/celnetwork` off `migrate/sbob`.)*

### `default-rules`
- **R0011 (egress)** now excludes loopback (`!startsWith('127.')`). Removing the
  old `is_private_ip` gate made R0011 fire on the bobctl functional harness — its
  port-forward tunnels into the pod netns, so each RESP test looks like egress to
  `127.0.0.1:<svc-port>`. That's a test artifact; a per-profile `127.0.0.1`
  allow-entry would be dangerous (masks a real local pivot), so it's excluded in
  the rule.
- **R0012 (ingress, new) — Unexpected Ingress Network Traffic.** Fires on an
  inbound peer that matches **neither** an `ipAddress`/CIDR ingress entry
  (`was_address_in_ingress`) **nor** a `podSelector` ingress entry
  (`was_selector_in_ingress`). Bound in `default-rule-binding`.

### Verified live
A client whose pod matches the ingress `podSelector` is **silent**; a
non-matching client — or an **absent** ingress stanza — **alerts**.
