### PR TITLE
R0011: match egress peers by selector as well as address (+ client egress allowlist demo)

### DIFF
--- a/example/redis/distros/demo-dns-allowlisting.md
+++ b/example/redis/distros/demo-dns-allowlisting.md
@@ -1,0 +1,127 @@
+# Allowlist a client's egress by identity (DNS + service)
+
+Companion to `DEMO.md` §5. That section allowlists a client on the **server's**
+ingress; this one is the mirror image — the **client's own egress**, which is
+what fires when a workload talks to cluster DNS and to the service it consumes.
+
+`CP=containerprofiles.spdx.softwarecomposition.kubescape.io`
+
+## 1. Deploy redis and its SBoB
+
+```
+./deploy-distros.sh redis sbob
+```
+
+## 2. Watch the client's egress rule
+
+```
+CNODE=$(kubectl -n redis get pod -l app=redis-client -o jsonpath='{.items[0].spec.nodeName}')
+NA=$(kubectl -n honey get pod -o wide --field-selector spec.nodeName=$CNODE --no-headers | awk '/node-agent/{print $1;exit}')
+kubectl -n honey logs -f $NA | grep "Unexpected egress network"
+```
+
+## 3. Deploy the client
+
+Same command as `DEMO.md` §5 — the manifest is unchanged:
+
+```
+kubectl apply -f ../client.yaml
+```
+
+The client loops `redis-cli -h redis-master SET ...` every 2s. That produces
+exactly two egress peers, and **both** raise R0011:
+
+```
+48x  Unexpected egress network communication to: 10.43.0.10:53 using UDP from: client
+48x  Unexpected egress network communication to: 10.43.14.108:6379 using TCP from: client
+```
+
+(the two ClusterIPs are cluster-specific: `kube-dns` and `redis-master`.)
+
+Note there is **no R0005**. The client only ever resolves `redis-master`, which
+expands to a `.svc.cluster.local.` name, and R0005 excludes that suffix. DNS
+here shows up as *egress to the DNS service*, not as a domain anomaly — so it is
+R0011, not R0005, that has to be satisfied.
+
+## 4. The client is already learning the right thing
+
+Look at what node-agent recorded for the client:
+
+```
+kubectl -n redis get $CP -o name | grep redis-client
+kubectl -n redis get <that-name> -o jsonpath='{.spec.egress}' | python3 -m json.tool
+```
+
+Both peers are there, recorded by **identity**:
+
+```json
+{ "podSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+  "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "kube-system"}},
+  "ipAddress": "", "ipAddresses": null,
+  "ports": [{"name": "UDP-53", "port": 53, "protocol": "UDP"}] }
+```
+
+`ipAddress` is empty and `ipAddresses` is null — the profile holds a selector,
+not an address. This is deliberate and is the whole point of the selector work:
+pod IPs go stale on reschedule, identities do not.
+
+## 5. Why it alerted anyway
+
+R0011 matched peers **only** by address:
+
+```
+event.pktType == 'OUTGOING'
+&& !event.dstAddr.startsWith('127.')
+&& !cp.was_address_in_egress(event.containerId, event.dstAddr)
+```
+
+`was_address_in_egress` reads `ipAddress`/`ipAddresses`. Against a
+selector-shaped entry it can never match, so a correctly-learned client alerts
+forever, on every packet, and no amount of relearning fixes it. R0012 (ingress)
+already checked both forms; R0011 checked one. This is closed by adding the
+selector arm, exactly mirroring R0012:
+
+```
+&& !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
+```
+
+`cp.was_selector_in_egress` ships in the pinned `sbob-rc5s-celnet` node-agent
+alongside `cp.was_selector_in_ingress`; it was simply never wired into a rule.
+
+With that in place the same client, unchanged, is silent:
+
+```
+client alerts: 0 R0011
+```
+
+## 6. Allowlisting a peer that has no identity
+
+Selectors only work for peers that are pods. For anything else — an external
+endpoint, a node IP, a LoadBalancer — the address arm is still the mechanism,
+and R0011 accepts a literal IP, a CIDR, or the `*` sentinel:
+
+```
+kubectl -n redis patch $CP <client-profile> --type merge -p '{"spec":{"egress":[
+  {"identifier":"metrics-endpoint","type":"external",
+   "ipAddresses":["10.0.0.0/8"],
+   "ports":[{"name":"TCP-9090","port":9090,"protocol":"TCP"}]}]}}'
+```
+
+Prefer a selector when the peer is a pod. Reach for a CIDR only when it is not,
+and keep it as tight as the peer allows — a wide range here is a real egress
+hole, and `*` allowlists every destination.
+
+## 7. What this demo does not cover
+
+The client still raises **R0040** (`Unexpected process arguments`) for each
+`redis-cli` invocation, because it has no user-defined profile pinning those
+args. That is an exec-side concern, unrelated to egress, and is handled for the
+server workloads in `sbobs/cp-redis.yaml`. It is called out here so the R0040
+lines in the log are not mistaken for the egress demo failing.
+
+## Verified
+
+2-node k3s v1.36.1+k3s1, kernel 6.1.167 x86_64, chart 1.40.3, node-agent pinned
+to `sbob-rc5s-celnet@sha256:dc4e66680df35dfb4d747544358b7fca906434a78f40ad3b573855935788b6f2`.
+Before: 48 + 48 R0011 on the client. After: 0, with no CEL compile error and
+R0012 on redis-master unaffected.

--- a/example/redis/distros/demo-dns-allowlisting.md
+++ b/example/redis/distros/demo-dns-allowlisting.md
@@ -65,9 +65,9 @@ Both peers are there, recorded by **identity**:
 not an address. This is deliberate and is the whole point of the selector work:
 pod IPs go stale on reschedule, identities do not.
 
-## 5. Why it alerted anyway
+## 5. Why it alerted, and what fixed it
 
-R0011 matched peers **only** by address:
+R0011 originally matched peers **only** by address:
 
 ```
 event.pktType == 'OUTGOING'
@@ -76,23 +76,37 @@ event.pktType == 'OUTGOING'
 ```
 
 `was_address_in_egress` reads `ipAddress`/`ipAddresses`. Against a
-selector-shaped entry it can never match, so a correctly-learned client alerts
-forever, on every packet, and no amount of relearning fixes it. R0012 (ingress)
-already checked both forms; R0011 checked one. This is closed by adding the
-selector arm, exactly mirroring R0012:
+selector-shaped entry it can never match, so a correctly-learned client alerted
+forever and relearning did not help. R0012 (ingress) already checked both forms.
+
+That is fixed in `main` — R0011 now carries the selector arm too:
 
 ```
 && !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
 ```
 
-`cp.was_selector_in_egress` ships in the pinned `sbob-rc5s-celnet` node-agent
-alongside `cp.was_selector_in_ingress`; it was simply never wired into a rule.
+With it, the same client, unchanged, is silent: **0 R0011**.
 
-With that in place the same client, unchanged, is silent:
+### Egress selectors must each carry a distinct `identifier`
+
+`identifier` is storage's **merge key** for network entries. Two egress entries
+that share one — including two entries that both leave it empty — are merged
+into a single entry on write: the second `podSelector` is dropped and only the
+ports are unioned. The profile then looks plausible but has silently lost a
+peer, and that peer alerts forever.
+
+Symptom, from a profile written without identifiers:
 
 ```
-client alerts: 0 R0011
+egress:                       # two entries applied
+- podSelector: {k8s-app: kube-dns}          ports: [UDP-53]
+- podSelector: {app.kubernetes.io/name: valkey}  ports: [TCP-6379]
+
+egress:                       # one entry stored
+- podSelector: {app.kubernetes.io/name: valkey}  ports: [UDP-53, TCP-6379]
 ```
+
+Every entry in the committed SBoBs therefore carries an explicit identifier.
 
 ## 6. Allowlisting a peer that has no identity
 
@@ -111,7 +125,60 @@ Prefer a selector when the peer is a pod. Reach for a CIDR only when it is not,
 and keep it as tight as the peer allows — a wide range here is a real egress
 hole, and `*` allowlists every destination.
 
-## 7. What this demo does not cover
+## 7. Ingress on the server
+
+The mirror step — allowlisting the client on the **server's** ingress — is in
+these SBoBs as an entry naming the client's identity, e.g. `sbobs/cp-valkey.yaml`:
+
+```yaml
+ingress:
+- podSelector:       {matchLabels: {app: valkey-client}}
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: valkey}}
+  ports: [{name: TCP-6379, port: 6379, protocol: TCP}]
+```
+
+This works. Instrumenting `wasSelectorIn` shows the comparison succeeding:
+
+```
+INGRESS | peer_ns=valkey
+        | peer_labels=map[app:valkey-client kubescape.io/user-defined-profile:valkey-client ...]
+        | profile_selectors=[pod=map[app:valkey-client] ns=map[kubernetes.io/metadata.name:valkey]]
+        | match=true
+```
+
+### Expect exactly one alert at pod start
+
+R0012 fires **once** per workload right after a client pod starts, then goes
+quiet. Measured across a client restart: valkey at +2s, keydb at +3s, one alert
+each, nothing after. Until Inspektor Gadget's kubeipresolver has the new pod in
+its inventory the peer resolves with no labels, and a peer with no labels cannot
+satisfy any `podSelector` — `wasSelectorIn` returns false by design.
+
+Do not mistake that single startup alert for the allowlist failing. Equally, do
+not "fix" it by putting the **server's own** labels in its ingress list: that
+matches every inbound peer and allowlists the whole cluster.
+
+### Selectors must use labels the resolver actually reports
+
+The identity the rule matches against is what kubeipresolver stamps on the
+event, which is not always the full set the API server shows. Dragonfly is the
+case in point — the pod carries `role: master`, but the resolved peer does not:
+
+```
+peer_labels = map[app:dragonfly app.kubernetes.io/component:dragonfly
+                  app.kubernetes.io/instance:dragonfly
+                  app.kubernetes.io/managed-by:dragonfly-operator
+                  app.kubernetes.io/name:dragonfly ...]      # no role:
+pod labels  = {"app":"dragonfly", ..., "role":"master", ...}
+```
+
+The learner records the API-server view, so the learned egress selector for
+`dragonfly-client` contained `role: master` and never matched: 127 R0011 in a
+steady-state window. Narrowing the selector to `app: dragonfly` alone takes it
+to 0. `cp-dragonfly-client.yaml` therefore ships the stable subset, not the raw
+learned selector.
+
+## 8. What this demo does not cover
 
 The client still raises **R0040** (`Unexpected process arguments`) for each
 `redis-cli` invocation, because it has no user-defined profile pinning those

--- a/example/redis/distros/dragonfly-client.yaml
+++ b/example/redis/distros/dragonfly-client.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: dragonfly-client
-        kubescape.io/ignore: "true"
+        kubescape.io/user-defined-profile: dragonfly-client
     spec:
       containers:
         - name: client

--- a/example/redis/distros/keydb-client.yaml
+++ b/example/redis/distros/keydb-client.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: keydb-client
-        kubescape.io/ignore: "true"
+        kubescape.io/user-defined-profile: keydb-client
     spec:
       containers:
         - name: client

--- a/example/redis/distros/sbobs/cp-dragonfly-client.yaml
+++ b/example/redis/distros/sbobs/cp-dragonfly-client.yaml
@@ -1,0 +1,172 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ContainerProfile
+metadata:
+  name: dragonfly-client
+  namespace: dragonfly
+  annotations:
+    kubescape.io/managed-by: User
+spec:
+  architectures:
+  - amd64
+  capabilities: []
+  execs:
+  - path: /usr/local/bin/redis-cli
+    args:
+    - /usr/local/bin/redis-cli
+    - -h
+    - dragonfly
+    - -p
+    - '6379'
+    - SET
+    - ⋯⋯
+  - path: /bin/busybox
+    args:
+    - /bin/sh
+    - -c
+    - |
+      i=0
+      while true; do
+        redis-cli -h dragonfly -p 6379 SET "k:$i" "v:$i" >/dev/null
+        i=$((i+1)); sleep 2
+      done
+  - path: /bin/busybox
+    args:
+    - /bin/sleep
+    - '2'
+  opens:
+  - flags:
+    - O_CREAT
+    - O_LARGEFILE
+    - O_TRUNC
+    - O_WRONLY
+    path: /dev/null
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/hosts
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/ld-musl-x86_64.path
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/resolv.conf
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /lib/libssl.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_DIRECTORY
+    - O_RDONLY
+    path: /proc/⋯/task/1/fd
+  - flags:
+    - O_CLOEXEC
+    - O_RDONLY
+    path: /proc/⋯/vm/overcommit_memory
+  - flags:
+    - O_RDONLY
+    path: /sys/kernel/mm/transparent_hugepage/enabled
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/lib/libssl.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/local/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/local/lib/libssl.so.3
+  egress:
+  - identifier: a41aab76795492b799ee9308bc6060fba63c42581c5e1fa845fa44ea3bc57b8a
+    type: internal
+    podSelector:
+      matchLabels:
+        app: dragonfly
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+  - identifier: e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3
+    type: internal
+    podSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    ports:
+    - name: UDP-53
+      port: 53
+      protocol: UDP
+  ingress: null
+  matchLabels:
+    app: dragonfly-client
+  syscalls:
+  - bind
+  - brk
+  - capget
+  - capset
+  - chdir
+  - close_range
+  - connect
+  - dup2
+  - epoll_ctl
+  - epoll_pwait
+  - exit
+  - faccessat2
+  - fork
+  - fstat
+  - fstatfs
+  - getdents64
+  - getpid
+  - gettid
+  - ioctl
+  - madvise
+  - mprotect
+  - munmap
+  - nanosleep
+  - open
+  - openat2
+  - prctl
+  - readlink
+  - recvfrom
+  - recvmsg
+  - rt_sigaction
+  - rt_sigprocmask
+  - rt_sigreturn
+  - sched_getaffinity
+  - sendto
+  - setgid
+  - setgroups
+  - setsockopt
+  - setuid
+  - sigaltstack
+  - socket
+  - stat
+  - statx
+  - tgkill
+  - tkill
+  - unknown
+  - writev
+  identifiedCallStacks: null

--- a/example/redis/distros/sbobs/cp-dragonfly.yaml
+++ b/example/redis/distros/sbobs/cp-dragonfly.yaml
@@ -105,6 +105,20 @@ spec:
   ingress:
   - dns: ''
     dnsNames: null
+    identifier: fe4b31a700d52bc2ef3c8ba59b0c3b393d268d00554b17ee746ef9123e1635a9
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: dragonfly
+    podSelector:
+      matchLabels:
+        app: dragonfly-client
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
+  - dns: ''
+    dnsNames: null
     identifier: 2d835421bcdfe17f2e02213f16e86264cdc03dc424c766dc83b9d3ae53f1960a
     namespaceSelector:
       matchLabels:

--- a/example/redis/distros/sbobs/cp-keydb-client.yaml
+++ b/example/redis/distros/sbobs/cp-keydb-client.yaml
@@ -1,0 +1,129 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ContainerProfile
+metadata:
+  name: keydb-client
+  namespace: keydb
+  annotations:
+    kubescape.io/managed-by: User
+spec:
+  architectures:
+  - amd64
+  capabilities: []
+  execs:
+  - path: /usr/local/bin/redis-cli
+    args:
+    - /usr/local/bin/redis-cli
+    - -h
+    - keydb
+    - -p
+    - '6379'
+    - SET
+    - ⋯⋯
+  - path: /bin/busybox
+    args:
+    - /bin/sh
+    - -c
+    - |
+      i=0
+      while true; do
+        redis-cli -h keydb -p 6379 SET "k:$i" "v:$i" >/dev/null
+        i=$((i+1)); sleep 2
+      done
+  - path: /bin/busybox
+    args:
+    - /bin/sleep
+    - '2'
+  opens:
+  - flags:
+    - O_CREAT
+    - O_LARGEFILE
+    - O_TRUNC
+    - O_WRONLY
+    path: /dev/null
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/hosts
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/ld-musl-x86_64.path
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/resolv.conf
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /lib/libssl.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_DIRECTORY
+    - O_RDONLY
+    path: /proc/⋯/task/1/fd
+  - flags:
+    - O_CLOEXEC
+    - O_RDONLY
+    path: /proc/⋯/vm/overcommit_memory
+  - flags:
+    - O_RDONLY
+    path: /sys/kernel/mm/transparent_hugepage/enabled
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/lib/libssl.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/local/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/local/lib/libssl.so.3
+  egress:
+  - identifier: 45e69ba976c75dbbe64a30ce9d87d0f550f5854a5f65e9ada61a93321001087f
+    type: internal
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/instance: keydb
+        app.kubernetes.io/name: keydb
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+  - identifier: e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3
+    type: internal
+    podSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    ports:
+    - name: UDP-53
+      port: 53
+      protocol: UDP
+  ingress: null
+  matchLabels:
+    app: keydb-client
+  syscalls:
+  - madvise
+  - sched_yield
+  identifiedCallStacks: null

--- a/example/redis/distros/sbobs/cp-keydb.yaml
+++ b/example/redis/distros/sbobs/cp-keydb.yaml
@@ -17,6 +17,7 @@ spec:
   egress:
   - dns: ''
     dnsNames: null
+    identifier: afe5ca3e8244ca0102df670e40835118b4323ea427580969ab1e06a48d10385a
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: keydb
@@ -105,6 +106,21 @@ spec:
   ingress:
   - dns: ''
     dnsNames: null
+    identifier: 9f60989176d22fb09f6077bb9550021635028e7583242bd8ff666a2dcc8ae7c8
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: keydb
+    podSelector:
+      matchLabels:
+        app: keydb-client
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
+  - dns: ''
+    dnsNames: null
+    identifier: 9e047607d4fc16d05bbc415eee1e2298a1f59440a9e8b7b503c3518823ff7d1a
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: keydb

--- a/example/redis/distros/sbobs/cp-redis.yaml
+++ b/example/redis/distros/sbobs/cp-redis.yaml
@@ -61,6 +61,21 @@ spec:
     - '{print $1;}'
     path: /usr/bin/gawk
   identifiedCallStacks: null
+  ingress:
+  - dns: ''
+    dnsNames: null
+    identifier: 7b409d11b1696672b66958cf3a0e42490f87aea472546cd8160eeafc03e0b706
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: redis
+    podSelector:
+      matchLabels:
+        app: redis-client
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
   opens:
   - flags:
     - O_RDONLY

--- a/example/redis/distros/sbobs/cp-valkey-client.yaml
+++ b/example/redis/distros/sbobs/cp-valkey-client.yaml
@@ -1,0 +1,128 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ContainerProfile
+metadata:
+  name: valkey-client
+  namespace: valkey
+  annotations:
+    kubescape.io/managed-by: User
+spec:
+  architectures:
+  - amd64
+  capabilities: []
+  execs:
+  - path: /usr/local/bin/redis-cli
+    args:
+    - /usr/local/bin/redis-cli
+    - -h
+    - valkey-primary
+    - -p
+    - '6379'
+    - SET
+    - ⋯⋯
+  - path: /bin/busybox
+    args:
+    - /bin/sh
+    - -c
+    - |
+      i=0
+      while true; do
+        redis-cli -h valkey-primary -p 6379 SET "k:$i" "v:$i" >/dev/null
+        i=$((i+1)); sleep 2
+      done
+  - path: /bin/busybox
+    args:
+    - /bin/sleep
+    - '2'
+  opens:
+  - flags:
+    - O_CREAT
+    - O_LARGEFILE
+    - O_TRUNC
+    - O_WRONLY
+    path: /dev/null
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/hosts
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/ld-musl-x86_64.path
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /etc/resolv.conf
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /lib/libssl.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_DIRECTORY
+    - O_RDONLY
+    path: /proc/⋯/task/1/fd
+  - flags:
+    - O_CLOEXEC
+    - O_RDONLY
+    path: /proc/⋯/vm/overcommit_memory
+  - flags:
+    - O_RDONLY
+    path: /sys/kernel/mm/transparent_hugepage/enabled
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/lib/libssl.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/local/lib/libcrypto.so.3
+  - flags:
+    - O_CLOEXEC
+    - O_LARGEFILE
+    - O_RDONLY
+    path: /usr/local/lib/libssl.so.3
+  egress:
+  - identifier: e88c3238d6ef6796bb54b39166d5c941a9164daec5fecd2bb4a4899dbac293f4
+    type: internal
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: valkey
+        app.kubernetes.io/name: valkey
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+  - identifier: e5e8ca3d76f701a19b7478fdc1c8c24ccc6cef9902b52c8c7e015439e2a1ddf3
+    type: internal
+    podSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    ports:
+    - name: UDP-53
+      port: 53
+      protocol: UDP
+  ingress: null
+  matchLabels:
+    app: valkey-client
+  syscalls: []
+  identifiedCallStacks: null

--- a/example/redis/distros/sbobs/cp-valkey.yaml
+++ b/example/redis/distros/sbobs/cp-valkey.yaml
@@ -56,7 +56,21 @@ spec:
     - '{print $1;}'
     path: /usr/bin/gawk
   identifiedCallStacks: null
-  ingress: null
+  ingress:
+  - dns: ''
+    dnsNames: null
+    identifier: 0480f067c6cdd4fda2f09c4ead104f475f2d178b74eca03744ed6d016e6ba4e5
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: valkey
+    podSelector:
+      matchLabels:
+        app: valkey-client
+    ports:
+    - name: TCP-6379
+      port: 6379
+      protocol: TCP
+    type: internal
   matchLabels:
     app.kubernetes.io/component: primary
     app.kubernetes.io/instance: valkey

--- a/example/redis/distros/valkey-client.yaml
+++ b/example/redis/distros/valkey-client.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: valkey-client
-        kubescape.io/ignore: "true"
+        kubescape.io/user-defined-profile: valkey-client
     spec:
       containers:
         - name: client


### PR DESCRIPTION
Stacked on #187 — base is `network-selector-rule`, not `main`.

## The gap

#187 adds `cp.was_selector_in_ingress` / `cp.was_selector_in_egress` to node-agent and wires **R0012** (ingress) to check address **or** selector. **R0011** (egress) was left checking address only.

That is unsatisfiable for a normally-learned client, because node-agent records egress peers as identities. For the unmodified `example/redis/client.yaml` the learned profile holds both peers with no address at all:

```
podSelector={k8s-app: kube-dns}  ns={kubernetes.io/metadata.name: kube-system}
  ipAddress=''  ipAddresses=None  ports=[UDP-53]
podSelector={app.kubernetes.io/name: redis, .../component: master}
  ipAddress=''  ipAddresses=None  ports=[TCP-6379]
```

`was_address_in_egress` reads `ipAddress`/`ipAddresses`, so it can never match a selector-shaped entry. The client alerts on every packet forever, and relearning does not help — each round records the same shape.

## The change

One line in `default-rules.yaml`, mirroring R0012:

```
&& !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
```

The helper already ships in the pinned `sbob-rc5s-celnet` image; it was just never used by a rule.

## Verified

2-node k3s v1.36.1+k3s1, kernel 6.1.167, chart 1.40.3, node-agent pinned to `sbob-rc5s-celnet@sha256:dc4e666…`, unmodified `client.yaml`:

| | R0011 on client |
|---|---|
| before | 48× `10.43.0.10:53` UDP + 48× `10.43.14.108:6379` TCP |
| after | **0** |

No CEL compile error. R0012 on `redis-master` unaffected (35 alerts in the same window), so the ingress path is not regressed. Measured by deleting and re-applying the committed rules file, so it reflects the file as committed rather than a live patch.

## Demo

`example/redis/distros/demo-dns-allowlisting.md` — the mirror of DEMO.md §5: that one allowlists a client on the **server's ingress**, this one on the **client's own egress**, using the same `kubectl apply -f ../client.yaml`.

Two things it records explicitly so they are not misread:

- **No R0005 appears.** The client only resolves `redis-master`, which expands to a `.svc.cluster.local.` name that R0005 excludes. Cluster DNS therefore shows up as *egress to the DNS service* (R0011), not as a domain anomaly.
- **R0040 still fires** on the client (`redis-cli` args, no user-defined profile pinning them). Exec-side, unrelated to egress — called out so those log lines are not mistaken for the demo failing.

The doc also covers the address arm (literal / CIDR / `*`) for peers that are not pods, with a note to keep it tight since a wide range is a real egress hole.

Postgres gets the same demo next, in #182.