### PR TITLE
docs: add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Software Bill of Behavior SBOB 
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/k8sstormcenter/bob/badge)](https://scorecard.dev/viewer/?uri=github.com/k8sstormcenter/bob)
+
 Imagine a software vendor distills all their knowledge of their own testing into a standard file and ships it `with each update` . Just like a Container Package-Insert (Packungsbeilage) 📦📃🩻
 
 


### PR DESCRIPTION
Adds the Scorecard badge under the README title. The Scorecard API already has published results for this repo, so the badge renders immediately (currently 4.7/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)