### PR TITLE
ci: add CodeQL SAST (Python, scoped to scripts/)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,18 +12,12 @@ permissions: read-all
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze (python)
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       actions: read
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: go
-            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -31,10 +25,12 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          languages: python
+          config: |
+            paths:
+              - scripts
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds a CodeQL workflow to satisfy the OpenSSF Scorecard **SAST** check (0/10).

- Language **python**, scoped via a `paths` config to **`scripts/`** only — the 11 Python tooling scripts (portable-sbob, clean-profile, emit-rule-sweep, etc.). Nothing else is scanned.
- Note: CodeQL has no shell analyzer, so the `.sh` files in `scripts/` are out of scope regardless.
- Runs on push + PR to main, plus weekly. Actions SHA-pinned; `read-all` default token, analyze job elevated only to `security-events: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)