### PR TITLE
fix(example/redis): create the redis namespace for the client

### DIFF
--- a/example/redis/00-namespace.yaml
+++ b/example/redis/00-namespace.yaml
@@ -2,3 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redis-demo
+---
+# The redis-client (client.yaml) runs in its own `redis` namespace with its own
+# user-defined SBoB (kubescape.io/user-defined-profile: redis-client). The skaffold
+# applies client.yaml, so this namespace must exist or the deploy fails with
+# `namespaces "redis" not found`.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redis


### PR DESCRIPTION
`skaffold deploy -f example/redis/skaffold.yaml` fails: 00-namespace.yaml creates only `redis-demo`, but client.yaml is in namespace `redis` (its own SBoB `redis-client`, per DEMO §5). Add the `redis` namespace so the example deploys standalone.